### PR TITLE
Optimize `FixedPointMath`

### DIFF
--- a/src/math/FixedPointMath.huff
+++ b/src/math/FixedPointMath.huff
@@ -12,7 +12,7 @@
 ////////////////////////////////////////////////////////////////
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L13
-#define macro MUL_WAD_DOWN() = takes (2) returns (1) {
+#define macro MUL_WAD_DOWN(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_MULWAD()  // [x, y, WAD]
@@ -20,7 +20,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L17
-#define macro MUL_WAD_UP() = takes (2) returns (1) {
+#define macro MUL_WAD_UP(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_MULWAD()  // [x, y, WAD]
@@ -28,7 +28,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L21
-#define macro DIV_WAD_DOWN() = takes (2) returns (1) {
+#define macro DIV_WAD_DOWN(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_DIVWAD()  // [x, WAD, y]
@@ -36,7 +36,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L25
-#define macro DIV_WAD_UP() = takes (2) returns (1) {
+#define macro DIV_WAD_UP(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_DIVWAD()  // [x, WAD, y]
@@ -44,7 +44,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L34
-#define macro EXP_WAD() = takes (1) returns (1) {
+#define macro EXP_WAD(fail) = takes (1) returns (1) {
     // Input stack:            [x]
 
     // When the result is < 0.5 we return zero. This happens when
@@ -172,14 +172,14 @@
     finish jump
 
     ret_zero:
-        0x00 0x00 mstore
+        0x00 dup1 mstore
         0x20 0x00 return
     finish:
     // Return stack:           [result]
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L92
-#define macro LN_WAD() = takes (1) returns (1) {
+#define macro LN_WAD(fail) = takes (1) returns (1) {
     // Input stack:            [x]
     0x00 dup2 sgt           // [x > 0, x]
     iszero                  // [x <= 0, x]
@@ -312,7 +312,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L29
-#define macro POW_WAD() = takes (2) returns (1) {
+#define macro POW_WAD(fail) = takes (2) returns (1) {
     // Input Stack:            [x, y]
     LN_WAD(fail)                // [lnWad(x), y]
     mul                     // [lnWad(x) * y]
@@ -326,7 +326,7 @@
 ////////////////////////////////////////////////////////////////
 
 // https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol#L34
-#define macro MUL_DIV_DOWN() = takes (3) returns (1) {
+#define macro MUL_DIV_DOWN(fail) = takes (3) returns (1) {
     // Input stack:      [x, y, denominator]
     dup1 dup3 mul     // [x * y, x, y, denominator]
     dup1              // [x * y, x * y, x, y, denominator]
@@ -349,7 +349,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol#L53
-#define macro MUL_DIV_UP() = takes (3) returns (1) {
+#define macro MUL_DIV_UP(fail) = takes (3) returns (1) {
     // Input stack:      [x, y, denominator]
     dup1 dup3 mul     // [x * y, x, y, denominator]
     dup1              // [x * y, x * y, x, y, denominator]
@@ -388,7 +388,7 @@
 
 // https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol#L74
 // TODO: Optimize, works but not great
-#define macro RPOW() = takes (3) returns (1) {
+#define macro RPOW(fail) = takes (3) returns (1) {
     // Input stack:                [x, n, scalar]
     dup1                        // [x, x, n, scalar]
     default jumpi               // Jump to "default" if x != 0
@@ -397,12 +397,12 @@
     //       the stack, so we fill it with extra items here in order to return
     //       the scalar or 0.
 
-    dup2 iszero                // [n == 0, x, n, scalar]
-    dup4 dup5 swap2            // [n == 0, scalar, scalar, x, n, scalar]
-    finish jumpi               // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
+    dup3 dup4                   // [scalar, scalar, x, n, scalar]
+    dup4 iszero                 // [n == 0, scalar, scalar, x, n, scalar]
+    finish jumpi                // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
 
     // 0 ** n = 0
-    0x00 0x00 finish jump       // Finish execution
+    0x00 dup1 finish jump       // Finish execution
 
     default:
         dup3                    // [scalar, x, n, scalar]
@@ -430,21 +430,21 @@
             // Revert if x ** 2 will overflow.
             dup3                // [x, result, scalar >> 1, x, n, scalar]
             0x80 shr            // [x >> 128, result, scalar >> 1, x, n, scalar]
-            <fail> jumpi        // [result, scalar >> 1, x, n, scalar]
 
             // Square x and duplicate it on the stack for use later.
-            dup3                // [x, result, scalar >> 1, x, n, scalar]
-            dup1 mul            // [x * x, result, scalar >> 1, x, n, scalar]
-            dup1                // [x * x, x * x, result, scalar >> 1, x, n, scalar]
+            dup4                // [x, x >> 128, result, scalar >> 1, x, n, scalar]
+            dup1 mul            // [x * x, x >> 128, result, scalar >> 1, x, n, scalar]
+            dup1                // [x * x, x * x, x >> 128, result, scalar >> 1, x, n, scalar]
 
             // Add x ** 2 to scalar >> 1
-            dup4                // [scalar >> 1, x * x, x * x, result, scalar >> 1, x, n, scalar]
-            add                 // [(scalar >> 1) + (x * x), x * x, result, scalar >> 1, x, n, scalar]
+            dup5                // [scalar >> 1, x * x, x * x, x >> 128, result, scalar >> 1, x, n, scalar]
+            add                 // [(scalar >> 1) + (x * x), x * x, x >> 128, result, scalar >> 1, x, n, scalar]
 
             // Revert if x ** 2 + scalar >> 1 overflowed
-            swap1               // [x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
-            dup2                // [(scalar >> 1) + (x * x), x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
-            lt <fail> jumpi     // [(scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            swap2               // [x >> 128, x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            swap1               // [x * x, x >> 128, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            dup3 lt             // [(scalar >> 1) + (x * x) < x * x, x >> 128, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            or <fail> jumpi     // [(scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
 
             // Set x to ((scalar >> 1) + (x * x)) / scalar
             dup6                // [scalar, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
@@ -475,16 +475,20 @@
             eq iszero           // [result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
             dup6                // [x, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
             iszero iszero       // [x != 0, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
-            and <fail> jumpi    // Revert if x * result overflowed
+            and                 // [x != 0 & result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
+            swap2               // [x * result, x * result, x != 0 & result != (x * result / x), result, scalar >> 1, x, n, scalar]
 
             // Round to the nearest number
-            dup4                // [scalar >> 1, x * result, x * result, result, scalar >> 1, x, n, scalar]
-            add                 // [(scalar >> 1) + (x * result), x * result, result, scalar >> 1, x, n, scalar]
+            dup5                // [scalar >> 1, x * result, x * result, x != 0 & result != (x * result / x), result, scalar >> 1, x, n, scalar]
+            add                 // [(scalar >> 1) + (x * result), x * result, x != 0 & result != (x * result / x), result, scalar >> 1, x, n, scalar]
 
             // Check if x ** 2 + scalar >> 1 overflowed
-            swap1               // [x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
-            dup2                // [(scalar >> 1) + (x * result), x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
-            lt <fail> jumpi     // Revert if ((scalar >> 1) + (x * result)) < x * result
+            swap2               // [x != 0 & result != (x * result / x), x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
+            swap1               // [x * result, x != 0 & result != (x * result / x), (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
+            dup3 lt             // [(scalar >> 1) + (x * result) < x * result, x != 0 & result != (x * result / x), (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
+            
+            // Revert if ((scalar >> 1) + (x * result)) < x * result OR x != 0 & result != (x * result / x)
+            or <fail> jumpi     // [(scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
 
             // Scale rounded result
             dup6                // [scalar, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
@@ -634,7 +638,7 @@
 }
 
 // https://github.com/transmissions11/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L352
-#define macro LOG_2() = takes (1) returns (1) {
+#define macro LOG_2(fail) = takes (1) returns (1) {
     // Input stack:                [x]
 
     dup1 iszero                 // [x == 0, x]
@@ -703,3 +707,4 @@
 #define macro ARRANGE_STACK_DIVWAD() = takes (3) returns (3) {
     // Input stack: [WAD, x, y]
     swap1        // [x, WAD, y]
+}

--- a/src/math/FixedPointMath.huff
+++ b/src/math/FixedPointMath.huff
@@ -39,7 +39,7 @@
 }
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L34
-#define macro EXP_WAD() = takes (1) returns (1) {
+#define macro EXP_WAD(fail) = takes (1) returns (1) {
     // Input stack:            [x]
 
     // When the result is < 0.5 we return zero. This happens when
@@ -54,7 +54,7 @@
     0x0755bf798b4a1bf1e5    // [0x0755bf798b4a1bf1e5, x]
     dup2                    // [x, 0x0755bf798b4a1bf1e5, x]
     slt iszero              // [x >= 0x0755bf798b4a1bf1e5, x]
-    fail jumpi              // [x]
+    <fail> jumpi            // [x]
 
     // x is now in the range (-42, 136) * 1e18. Convert to (-42, 136) * 2**96
     // for more intermediate precision and a binary basis. This base conversion
@@ -166,8 +166,6 @@
 
     finish jump
 
-    fail:
-        0x00 0x00 revert
     ret_zero:
         0x00 0x00 mstore
         0x20 0x00 return
@@ -175,11 +173,11 @@
     // Return stack:           [result]
 }
 
-#define macro LN_WAD() = takes (1) returns (1) {
+#define macro LN_WAD(fail) = takes (1) returns (1) {
     // Input stack:            [x]
     0x00 dup2 sgt           // [x > 0, x]
     iszero                  // [x <= 0, x]
-    fail jumpi              // [x]
+    <fail> jumpi              // [x]
 
     // We want to convert x from 10**18 fixed point to 2**96 fixed point.
     // We do this by multiplying by 2**96 / 10**18. But since
@@ -189,7 +187,7 @@
     // Reduce range of x to (1, 2) * 2**96
     // ln(2^k * x) = k * ln(2) + ln(x)
     0x60                    // [0x60, x]
-    dup2 LOG_2()            // [log2(x), 0x60, x]
+    dup2 LOG_2(fail)        // [log2(x), 0x60, x]
     sub                     // [k, x]
 
     dup2 dup2               // [k, x, k, x]
@@ -301,21 +299,19 @@
 
     finish jump
 
-    fail:
-        0x00 0x00 revert
     finish:
         // Clean stack
         swap1 pop
     // Return stack:           [result]
 }
 
-#define macro POW_WAD() = takes (2) returns (1) {
+#define macro POW_WAD(fail) = takes (2) returns (1) {
     // Input Stack:            [x, y]
-    LN_WAD()                // [lnWad(x), y]
+    LN_WAD(fail)                // [lnWad(x), y]
     mul                     // [lnWad(x) * y]
     [WAD] swap1             // [lnWad(x) * y, 1e18]
     sdiv                    // [(lnWad(x) * y) / 1e18]
-    EXP_WAD()               // [result]
+    EXP_WAD(fail)               // [result]
 }
 
 ////////////////////////////////////////////////////////////////
@@ -384,20 +380,23 @@
 }
 
 // https://github.com/Rari-Capital/solmate/blob/main/src/utils/FixedPointMathLib.sol#L74
-// TODO: Optimize, works but not great
-#define macro RPOW() = takes (3) returns (1) {
+// TODO: Optimize
+#define macro RPOW(fail) = takes (3) returns (1) {
     // Input stack:                [x, n, scalar]
     dup1                        // [x, x, n, scalar]
 
     iszero iszero default jumpi // Jump to "default" if x != 0
 
-    dup2                        // [n, x, n, scalar]
-    iszero finish jumpi         // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
+    // TODO: Fix hack- code following `finish` label pops four items off of 
+    //       the stack, so we fill it with extra items here in order to return
+    //       the scalar or 0.
 
-    // 0x60 is blank, no need to set it.
+    dup2 iszero                // [n == 0, x, n, scalar]
+    dup4 dup5 swap2            // [n == 0, scalar, scalar, x, n, scalar]
+    finish jumpi               // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
+
     // 0 ** n = 0
-    pop                         // [n, scalar] - Others will be popped in `finish`
-    finish jump                 // Finish execution
+    0x00 0x00 finish jump       // Finish execution
 
     default:
         dup3                    // [scalar, x, n, scalar]
@@ -429,7 +428,7 @@
             // Revert if x ** 2 will overflow.
             dup3                // [x, result, scalar >> 1, x, n, scalar]
             0x80 shr            // [x >> 128, result, scalar >> 1, x, n, scalar]
-            fail jumpi          // [result, scalar >> 1, x, n, scalar]
+            <fail> jumpi        // [result, scalar >> 1, x, n, scalar]
 
             // Square x and duplicate it on the stack for use later.
             dup3                // [x, result, scalar >> 1, x, n, scalar]
@@ -443,7 +442,7 @@
             // Revert if x ** 2 + scalar >> 1 overflowed
             swap1               // [x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
             dup2                // [(scalar >> 1) + (x * x), x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
-            lt fail jumpi       // [(scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            lt <fail> jumpi     // [(scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
 
             // Set x to ((scalar >> 1) + (x * x)) / scalar
             dup6                // [scalar, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
@@ -475,7 +474,7 @@
             eq iszero           // [result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
             dup6                // [x, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
             iszero iszero       // [x != 0, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
-            and fail jumpi      // Revert if x * result overflowed
+            and <fail> jumpi    // Revert if x * result overflowed
 
             // Round to the nearest number
             dup4                // [scalar >> 1, x * result, x * result, result, scalar >> 1, x, n, scalar]
@@ -484,7 +483,7 @@
             // Check if x ** 2 + scalar >> 1 overflowed
             swap1               // [x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
             dup2                // [(scalar >> 1) + (x * result), x * result, (scalar >> 1) + (x * result)]
-            lt fail jumpi       // Revert if ((scalar >> 1) + (x * result)) < x * result
+            lt <fail> jumpi     // Revert if ((scalar >> 1) + (x * result)) < x * result
 
             // Scale rounded result
             dup6                // [scalar, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
@@ -493,9 +492,6 @@
             swap1 pop           // [result, scalar >> 1, x, n, scalar]
 
             loop jump           // Continue loop
-        // Revert
-        fail:
-            0x00 0x00 revert
         // Return result
         finish:
             // Clean Stack
@@ -635,11 +631,11 @@
     swap1 sub                   // [z - (x / z) < z]
 }
 
-#define macro LOG_2() = takes (1) returns (1) {
+#define macro LOG_2(fail) = takes (1) returns (1) {
     // Input stack:                [x]
 
     dup1 iszero                 // [x == 0, x]
-    fail jumpi                  // [x]
+    <fail> jumpi                // [x]
 
     dup1                        // [x, x]
     0xffffffffffffffffffffffffffffffff
@@ -688,11 +684,6 @@
     or                          // [r, x]
     swap1 pop                   // [r]
 
-    finish jump
-
-    fail:
-        0x00 0x00 revert
-    finish:
     // Return stack:            // [result]
 }
 

--- a/src/math/FixedPointMath.huff
+++ b/src/math/FixedPointMath.huff
@@ -7,35 +7,35 @@
 ////////////////////////////////////////////////////////////////
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L13
-#define macro MUL_WAD_DOWN() = takes (2) returns (1) {
+#define macro MUL_WAD_DOWN(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_MULWAD()  // [x, y, WAD]
-    MUL_DIV_DOWN()          // [result]
+    MUL_DIV_DOWN(fail)      // [result]
 }
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L17
-#define macro MUL_WAD_UP() = takes (2) returns (1) {
+#define macro MUL_WAD_UP(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_MULWAD()  // [x, y, WAD]
-    MUL_DIV_UP()            // [result]
+    MUL_DIV_UP(fail)        // [result]
 }
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L21
-#define macro DIV_WAD_DOWN() = takes (2) returns (1) {
+#define macro DIV_WAD_DOWN(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_DIVWAD()  // [x, WAD, y]
-    MUL_DIV_DOWN()
+    MUL_DIV_DOWN(fail)
 }
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L25
-#define macro DIV_WAD_UP() = takes (2) returns (1) {
+#define macro DIV_WAD_UP(fail) = takes (2) returns (1) {
     // Input stack:            [x, y]
     [WAD]                   // [WAD, x, y]
     ARRANGE_STACK_DIVWAD()  // [x, WAD, y]
-    MUL_DIV_UP()            // [result]
+    MUL_DIV_UP(fail)        // [result]
 }
 
 // https://github.com/Rari-Capital/solmate/blob/v7/src/utils/FixedPointMathLib.sol#L34
@@ -323,92 +323,63 @@
 ////////////////////////////////////////////////////////////////
 
 // https://github.com/Rari-Capital/solmate/blob/main/src/utils/FixedPointMathLib.sol#L34
-#define macro MUL_DIV_DOWN() = takes (3) returns (1) {
+#define macro MUL_DIV_DOWN(fail) = takes (3) returns (1) {
     // Input stack:      [x, y, denominator]
-    dup3              // [denominator, x, y, denominator]
-    dup3              // [y, denominator, x, y, denominator]
-    dup3              // [x, y, denominator, x, y, denominator]
+    dup1 dup3 mul     // [x * y, x, y, denominator]
+    dup1              // [x * y, x * y, x, y, denominator]
+    swap2 dup1        // [x, x, x * y, x * y, y, denominator]
 
-    mul               // [x * y, denominator, x, y, denominator]
-    0x00 mstore       // [denominator, x, y, denominator]
+    iszero            // [x == 0, x, x * y, x * y, y, denominator]
+    swap2             // [x * y, x, x == 0, x * y, y, denominator]
+    div               // [(x * y) / x, x == 0, x * y, y, denominator]
+    dup4 eq           // [y == (x * y) / x, x == 0, x * y, y, denominator]
+    or                // [y == (x * y) / x | x == 0, x * y, y, denominator]
+    swap2 pop         // [x * y, y == (x * y) / x | x == 0, denominator]
+    swap1 dup3        // [denominator, y == (x * y) / x | x == 0, x * y, denominator]
+    iszero iszero     // [denominator != 0, y == (x * y) / x | x == 0, x * y, denominator]
+    and               // [denominator != 0 & y == (x * y) / x | x == 0, x * y, denominator]
 
-    iszero iszero     // [denominator != 0, x, y, denominator]
+    iszero <fail> jumpi // [x * y, denominator]
 
-    swap1             // [x, denominator != 0, y, denominator]
-    dup1              // [x, x, denominator != 0, y, denominator]
-    iszero            // [x == 0, x, denominator != 0, y, denominator]
-
-    swap1             // [x, x == 0, denominator != 0, y, denominator]
-    0x00 mload        // [x * y, x, x == 0, denominator != 0, y, denominator]
-    div               // [(x * y) / x, x == 0, denominator != 0, y, denominator]
-
-    dup4              // [y, (x * y) / x, x == 0, denominator != 0, y, denominator]
-    eq                // [y == (x * y) / x, x == 0, denominator != 0, y, denominator]
-    or                // [y == (x * y) / x | x == 0, denominator != 0, y, denominator]
-    and               // [(y == (x * y) / x | x == 0) & denominator != 0, y, denominator]
-
-    iszero fail jumpi // Revert if (y == (x * y) / x | x == 0) & denominator != 0 is not satisfied
-
-    pop               // [denominator]
-    0x00 mload        // [x * y, denominator]
     div               // [(x * y) / denominator]
-
-    finish jump
-
-    fail:
-        0x00 0x00 revert
-    finish:
     // Return stack:     [(x * y) / denominator]
 }
 
 // https://github.com/Rari-Capital/solmate/blob/main/src/utils/FixedPointMathLib.sol#L53
-#define macro MUL_DIV_UP() = takes (3) returns (1) {
+#define macro MUL_DIV_UP(fail) = takes (3) returns (1) {
     // Input stack:      [x, y, denominator]
-    dup3              // [denominator, x, y, denominator]
-    dup3              // [y, denominator, x, y, denominator]
-    dup3              // [x, y, denominator, x, y, denominator]
+    dup1 dup3 mul     // [x * y, x, y, denominator]
+    dup1              // [x * y, x * y, x, y, denominator]
+    swap2 dup1        // [x, x, x * y, x * y, y, denominator]
 
-    mul               // [x * y, denominator, x, y, denominator]
-    0x00 mstore       // [denominator, x, y, denominator]
+    iszero            // [x == 0, x, x * y, x * y, y, denominator]
+    swap2             // [x * y, x, x == 0, x * y, y, denominator]
+    div               // [(x * y) / x, x == 0, x * y, y, denominator]
+    dup4 eq           // [y == (x * y) / x, x == 0, x * y, y, denominator]
+    or                // [y == (x * y) / x | x == 0, x * y, y, denominator]
+    swap2 pop         // [x * y, y == (x * y) / x | x == 0, denominator]
+    swap1 dup3        // [denominator, y == (x * y) / x | x == 0, x * y, denominator]
+    iszero iszero     // [denominator != 0, y == (x * y) / x | x == 0, x * y, denominator]
+    and               // [denominator != 0 & y == (x * y) / x | x == 0, x * y, denominator]
 
-    iszero iszero     // [denominator != 0, x, y, denominator]
+    iszero <fail> jumpi // [x * y, denominator]
 
-    dup2              // [x, denominator != 0, x, y, denominator]
-    iszero            // [x == 0, denominator != 0, x, y, denominator]
+    dup1              // [x * y, x * y, denominator]
+    iszero iszero     // [x * y != 0, x * y, denominator]
 
-    dup3              // [x, x == 0, denominator != 0, x, y, denominator]
-    0x00 mload        // [x * y, x, x == 0, denominator != 0, x, y, denominator]
-    div               // [(x * y) / x, x == 0, denominator != 0, x, y, denominator]
+    dup3              // [denominator, x * y != 0, x * y, denominator]
+    0x01              // [1, denominator, x * y != 0, x * y, denominator]
+    dup4              // [x * y, 1, denominator, x * y != 0, x * y, denominator]
+    sub               // [x * y - 1, denominator, x * y != 0, x * y, denominator]
+    div               // [x * y - 1 / denominator, x * y != 0, x * y, denominator]
+    0x01              // [1, x * y - 1 / denominator, x * y != 0, x * y, denominator]
+    add               // [(x * y - 1 / denominator) + 1, x * y != 0, x * y, denominator]
 
-    dup5              // [y, (x * y) / x, x == 0, denominator != 0, x, y, denominator]
-    eq                // [y == (x * y) / x, x == 0, denominator != 0, x, y, denominator]
-    or                // [y == (x * y) / x | x == 0, denominator != 0, x, y, denominator]
-    and               // [y == (x * y) / x | x == 0 & denominator != 0, x, y, denominator]
-
-    iszero fail jumpi // Revert if (y == (x * y) / x | x == 0) & denominator != 0 is not satisfied
-
-    0x00 mload        // [x * y, x, y, denominator]
-    iszero iszero     // [x * y != 0, x, y, denominator]
-
-    dup4              // [denominator, x * y != 0, x, y, denominator]
-    0x01              // [1, denominator, x * y != 0, x, y, denominator]
-    0x00 mload        // [x * y, 1, denominator, x * y != 0, x, y, denominator]
-    sub               // [x * y - 1, denominator, x * y != 0, x, y, denominator]
-    div               // [x * y - 1 / denominator, x * y != 0, x, y, denominator]
-    0x01              // [1, x * y - 1 / denominator, x * y != 0, x, y, denominator]
-    add               // [(x * y - 1 / denominator) + 1, x * y != 0, x, y, denominator]
-
-    mul               // [((x * y - 1 / denominator) + 1) * (x * y != 0), x, y, denominator]
+    mul               // [((x * y - 1 / denominator) + 1) * (x * y != 0), x * y, denominator]
 
     // Clear extra stack items before continuing
-    swap3             // [denominator, x, y, ((x * y - 1 / denominator) + 1) * (x * y != 0)]
-    pop pop pop       // [((x * y - 1 / denominator) + 1) * (x * y != 0)]
-
-    finish jump
-
-    fail:
-        0x00 0x00 revert
-    finish:
+    swap2             // [denominator, x * y, ((x * y - 1 / denominator) + 1) * (x * y != 0)]
+    pop pop           // [((x * y - 1 / denominator) + 1) * (x * y != 0)]
     // Return stack:     [((x * y - 1 / denominator) + 1) * (x * y != 0)]
 }
 

--- a/src/math/FixedPointMath.huff
+++ b/src/math/FixedPointMath.huff
@@ -389,123 +389,108 @@
     // Input stack:                [x, n, scalar]
     dup1                        // [x, x, n, scalar]
 
-    iszero zero jumpi           // Jump to "zero" if x == 0
-    default jump                // Jump to "default" if x != 0
+    iszero iszero default jumpi // Jump to "default" if x != 0
 
-    zero:
-        dup2                    // [n, x, n, scalar]
-        iszero zero_inner jumpi // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
+    dup2                        // [n, x, n, scalar]
+    iszero finish jumpi         // If n == 0 && x == 0, return the scalar (0 ** 0 = 1).
 
-        // 0x60 is blank, no need to set it.
-        // 0 ** n = 0
-        pop                     // [n, scalar] - Others will be popped in `finish`
-        finish jump             // Finish execution
+    // 0x60 is blank, no need to set it.
+    // 0 ** n = 0
+    pop                         // [n, scalar] - Others will be popped in `finish`
+    finish jump                 // Finish execution
 
-        // 0 ** 0 = 1
-        zero_inner:
-            swap2               // [scalar, n, x]
-            0x60 mstore         // [n, x]
-            finish jump         // Finish execution
     default:
-        0x20 mstore             // [n, scalar]
-        0x40 mstore             // [scalar]
-            
-        dup1                    // [scalar, scalar]
-        0x01 shr                // [scalar >> 1, scalar]
-        0x00 mstore             // [scalar]
+        dup3                    // [scalar, x, n, scalar]
+        0x01 shr                // [scalar >> 1, x, n, scalar]
 
-        0x02                    // [2, scalar]
-        0x40 mload              // [n, 2, scalar]
-        mod                     // [n % 2, scalar]
+        0x02                    // [2, scalar >> 1, x, n, scalar]
+        dup4                    // [n, 2, scalar >> 1, x, n, scalar]
+        mod                     // [n % 2, scalar >> 1, x, n, scalar]
 
-        iszero even jumpi       // Set result to scalar for now if n % 2 is even
-        odd jump                // Set result to x for now if n % 2 is odd
+        odd jumpi               // Set result to x for now if n % 2 is odd
+                                // Otherwise, set result to scalar for now if n % 2 is even
 
         // n % 2 is even
-        even:
-            dup1                // [scalar, scalar]
-            0x60 mstore         // [scalar]
-            loop jump           // Start loop
+        dup4                // [result, scalar >> 1, x, n, scalar]
+        loop jump           // Start loop
+
         // n % 2 is odd
         odd:
-            0x20 mload          // [x, scalar]
-            0x60 mstore         // [scalar]
-            loop jump           // Start loop
+            dup2                // [result, scalar >> 1, x, n, scalar]
         loop:
-            0x40 mload          // [n, scalar]
-            dup1                // [n, n, scalar]
-
-            iszero finish jumpi // If n = 0, the loop is finished.
+            dup4                // [n, result, scalar >> 1, x, n, scalar]
+            iszero finish jumpi // If n == 0, the loop is finished.
 
             // Divide n by 2
-            0x01 shr            // [n >> 1, scalar]
-            0x40 mstore         // [scalar]
+            dup4                // [n, result, scalar >> 1, x, n, scalar]
+            0x01 shr            // [n >> 1, result, scalar >> 1, x, n, scalar]
+            swap4 pop           // [result, scalar >> 1, x, n, scalar]
 
             // Revert if x ** 2 will overflow.
-            0x20 mload          // [x, scalar]
-            0x80 shr            // [x >> 128, scalar]
-            fail jumpi          // [scalar]
+            dup3                // [x, result, scalar >> 1, x, n, scalar]
+            0x80 shr            // [x >> 128, result, scalar >> 1, x, n, scalar]
+            fail jumpi          // [result, scalar >> 1, x, n, scalar]
 
             // Square x and duplicate it on the stack for use later.
-            0x20 mload          // [x, scalar]
-            dup1 mul            // [x * x, scalar]
-            dup1                // [x * x, x * x, scalar]
+            dup3                // [x, result, scalar >> 1, x, n, scalar]
+            dup1 mul            // [x * x, result, scalar >> 1, x, n, scalar]
+            dup1                // [x * x, x * x, result, scalar >> 1, x, n, scalar]
 
             // Add x ** 2 to scalar >> 1
-            0x00 mload          // [scalar >> 1, x * x, x * x, scalar]
-            add                 // [(scalar >> 1) + (x * x), x * x, scalar]
+            dup4                // [scalar >> 1, x * x, x * x, result, scalar >> 1, x, n, scalar]
+            add                 // [(scalar >> 1) + (x * x), x * x, result, scalar >> 1, x, n, scalar]
 
             // Revert if x ** 2 + scalar >> 1 overflowed
-            swap1               // [x * x, (scalar >> 1) + (x * x), scalar]
-            dup2                // [(scalar >> 1) + (x * x), x * x, (scalar >> 1) + (x * x), scalar]
-            lt fail jumpi       // [(scalar >> 1) + (x * x), scalar]
+            swap1               // [x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            dup2                // [(scalar >> 1) + (x * x), x * x, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            lt fail jumpi       // [(scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
 
             // Set x to ((scalar >> 1) + (x * x)) / scalar
-            dup2                // [scalar, (scalar >> 1) + (x * x), scalar]
-            swap1               // [(scalar >> 1) + (x * x), scalar, scalar]
-            div                 // [((scalar >> 1) + (x * x)) / scalar, scalar]
-            0x20 mstore         // [scalar]
+            dup6                // [scalar, (scalar >> 1) + (x * x), result, scalar >> 1, x, n, scalar]
+            swap1               // [(scalar >> 1) + (x * x), scalar, result, scalar >> 1, x, n, scalar]
+            div                 // [((scalar >> 1) + (x * x)) / scalar, result, scalar >> 1, x, n, scalar]
+            swap3 pop           // [result, scalar >> 1, x, n, scalar]
 
-            0x02                // [2, scalar]
-            0x40 mload          // [n, 2, scalar]
-            mod                 // [n % 2, scalar]
+            0x02                // [2, result, scalar >> 1, x, n, scalar]
+            dup5                // [n, 2, result, scalar >> 1, x, n, scalar]
+            mod                 // [n % 2, result, scalar >> 1, x, n, scalar]
 
-            // If n is odd, continue logic
-            odd_inner jumpi
-            // If n is even, continue loop
+            // If n is even, continue logic
+            even_inner jumpi
+            // If n is odd, continue loop
             loop jump
-        odd_inner:
+        even_inner:
             // Multiply x * result
-            0x60 mload          // [result]
-            0x20 mload          // [x, result]
-            mul                 // [x * result]
-            dup1                // [x * result, x * result]
-            dup1                // [x * result, x * result, x * result]
+            dup1                // [result, result, scalar >> 1, x, n, scalar]
+            dup4                // [x, result, result, scalar >> 1, x, n, scalar]
+            mul                 // [x * result, result, scalar >> 1, x, n, scalar]
+            dup1                // [x * result, x * result, result, scalar >> 1, x, n, scalar]
+            dup1                // [x * result, x * result, x * result, result, scalar >> 1, x, n, scalar]
 
             // Check if x * result overflowed
-            0x20 mload          // [x, x * result, x * result, x * result]
-            swap1               // [x * result, x, x * result, x * result]
-            div                 // [x * result / x, x * result, x * result]
-            0x60 mload          // [result, x * result / x, x * result, x * result]
-            eq iszero           // [result != (x * result / x), x * result, x * result]
-            0x20 mload          // [x, result != (x * result / x), x * result, x * result]
-            iszero iszero       // [x != 0, result != (x * result / x), x * result, x * result]
+            dup6                // [x, x * result, x * result, x * result, result, scalar >> 1, x, n, scalar]
+            swap1               // [x * result, x, x * result, x * result, result, scalar >> 1, x, n, scalar]
+            div                 // [x * result / x, x * result, x * result, result, scalar >> 1, x, n, scalar]
+            dup4                // [result, x * result / x, x * result, x * result, result, scalar >> 1, x, n, scalar]
+            eq iszero           // [result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
+            dup6                // [x, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
+            iszero iszero       // [x != 0, result != (x * result / x), x * result, x * result, result, scalar >> 1, x, n, scalar]
             and fail jumpi      // Revert if x * result overflowed
 
             // Round to the nearest number
-            0x00 mload          // [scalar >> 1, x * result, x * result]
-            add                 // [(scalar >> 1) + (x * result), x * result]
+            dup4                // [scalar >> 1, x * result, x * result, result, scalar >> 1, x, n, scalar]
+            add                 // [(scalar >> 1) + (x * result), x * result, result, scalar >> 1, x, n, scalar]
 
             // Check if x ** 2 + scalar >> 1 overflowed
-            swap1               // [x * result, (scalar >> 1) + (x * result)]
+            swap1               // [x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
             dup2                // [(scalar >> 1) + (x * result), x * result, (scalar >> 1) + (x * result)]
             lt fail jumpi       // Revert if ((scalar >> 1) + (x * result)) < x * result
 
             // Scale rounded result
-            dup2                // [scalar, ((scalar >> 1) + (x * result), scalar]
-            swap1               // [((scalar >> 1) + (x * result), scalar, scalar]
-            div                 // [((scalar >> 1) + (x * result)) / scalar, scalar]
-            0x60 mstore         // [scalar]
+            dup6                // [scalar, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
+            swap1               // [(scalar >> 1) + (x * result), scalar, result, scalar >> 1, x, n, scalar]
+            div                 // [(scalar >> 1) + (x * result)) / scalar, result, scalar >> 1, x, n, scalar]
+            swap1 pop           // [result, scalar >> 1, x, n, scalar]
 
             loop jump           // Continue loop
         // Revert
@@ -513,8 +498,10 @@
             0x00 0x00 revert
         // Return result
         finish:
-            pop pop             // [] - Clear stack
-            0x60 mload          // [result]
+            // Clean Stack
+            swap4               // [scalar, scalar >> 1, x, n, result]
+            pop pop pop pop     // [result]
+        // Return stack:           [result]
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/math/FixedPointMath.huff
+++ b/src/math/FixedPointMath.huff
@@ -384,8 +384,7 @@
 #define macro RPOW(fail) = takes (3) returns (1) {
     // Input stack:                [x, n, scalar]
     dup1                        // [x, x, n, scalar]
-
-    iszero iszero default jumpi // Jump to "default" if x != 0
+    default jumpi               // Jump to "default" if x != 0
 
     // TODO: Fix hack- code following `finish` label pops four items off of 
     //       the stack, so we fill it with extra items here in order to return
@@ -402,20 +401,16 @@
         dup3                    // [scalar, x, n, scalar]
         0x01 shr                // [scalar >> 1, x, n, scalar]
 
-        0x02                    // [2, scalar >> 1, x, n, scalar]
-        dup4                    // [n, 2, scalar >> 1, x, n, scalar]
-        mod                     // [n % 2, scalar >> 1, x, n, scalar]
+        dup4                    // [result, scalar >> 1, x, n, scalar]
+        0x02                    // [2, result, scalar >> 1, x, n, scalar]
+        dup5                    // [n, 2, result, scalar >> 1, x, n, scalar]
+        mod                     // [n % 2, result, scalar >> 1, x, n, scalar]
 
-        odd jumpi               // Set result to x for now if n % 2 is odd
-                                // Otherwise, set result to scalar for now if n % 2 is even
+        // Set result to scalar for now if n % 2 is even
+        iszero loop jumpi       // [result, scalar >> 1, x, n, scalar]]
 
-        // n % 2 is even
-        dup4                // [result, scalar >> 1, x, n, scalar]
-        loop jump           // Start loop
-
-        // n % 2 is odd
-        odd:
-            dup2                // [result, scalar >> 1, x, n, scalar]
+        // Set result to x for now if n % 2 is odd
+        pop dup2                // [result, scalar >> 1, x, n, scalar]
         loop:
             dup4                // [n, result, scalar >> 1, x, n, scalar]
             iszero finish jumpi // If n == 0, the loop is finished.
@@ -454,11 +449,10 @@
             dup5                // [n, 2, result, scalar >> 1, x, n, scalar]
             mod                 // [n % 2, result, scalar >> 1, x, n, scalar]
 
-            // If n is even, continue logic
-            even_inner jumpi
-            // If n is odd, continue loop
-            loop jump
-        even_inner:
+            // If n is even, continue loop
+            iszero loop jumpi
+            // If n is odd, continue logic
+            
             // Multiply x * result
             dup1                // [result, result, scalar >> 1, x, n, scalar]
             dup4                // [x, result, result, scalar >> 1, x, n, scalar]
@@ -482,7 +476,7 @@
 
             // Check if x ** 2 + scalar >> 1 overflowed
             swap1               // [x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
-            dup2                // [(scalar >> 1) + (x * result), x * result, (scalar >> 1) + (x * result)]
+            dup2                // [(scalar >> 1) + (x * result), x * result, (scalar >> 1) + (x * result), result, scalar >> 1, x, n, scalar]
             lt <fail> jumpi     // Revert if ((scalar >> 1) + (x * result)) < x * result
 
             // Scale rounded result

--- a/test/math/FixedPointMath.t.sol
+++ b/test/math/FixedPointMath.t.sol
@@ -243,6 +243,8 @@ contract FixedPointMathTest is Test {
         assertEq(math.rpow(2e18, 2, 1e18), 4e18);
         assertEq(math.rpow(2e8, 2, 1e8), 4e8);
         assertEq(math.rpow(8, 3, 1), 512);
+        assertEq(math.rpow(0, 0, 1e18), 1e18);
+        assertEq(math.rpow(0, 1, 1), 0);
     }
 
     function testSqrt() public {

--- a/test/math/mocks/FixedPointMathWrappers.huff
+++ b/test/math/mocks/FixedPointMathWrappers.huff
@@ -61,33 +61,33 @@
     0x20 0x00 return
 }
 
-#define macro RPOW_WRAPPER() = takes (0) returns (0) {
+#define macro RPOW_WRAPPER(fail) = takes (0) returns (0) {
     0x44 calldataload // [scalar]
     0x24 calldataload // [n, scalar]
     0x04 calldataload // [x, n, scalar]
-    RPOW()            // [result]
+    RPOW(fail)        // [result]
     0x00 mstore       // []
     0x20 0x00 return
 }
 
-#define macro EXP_WAD_WRAPPER() = takes (0) returns (0) {
+#define macro EXP_WAD_WRAPPER(fail) = takes (0) returns (0) {
     0x04 calldataload // [x]
-    EXP_WAD()         // [result]
+    EXP_WAD(fail)     // [result]
     0x00 mstore
     0x20 0x00 return
 }
 
-#define macro LN_WAD_WRAPPER() = takes (0) returns (0) {
+#define macro LN_WAD_WRAPPER(fail) = takes (0) returns (0) {
     0x04 calldataload // [x]
-    LN_WAD()          // [result]
+    LN_WAD(fail)      // [result]
     0x00 mstore
     0x20 0x00 return
 }
 
-#define macro POW_WAD_WRAPPER() = takes (0) returns (0) {
+#define macro POW_WAD_WRAPPER(fail) = takes (0) returns (0) {
     0x24 calldataload // [y]
     0x04 calldataload // [x, y]
-    POW_WAD()         // [result]
+    POW_WAD(fail)     // [result]
     0x00 mstore       // []
     0x20 0x00 return
 }
@@ -99,9 +99,9 @@
     0x20 0x00 return
 }
 
-#define macro LOG_2_WRAPPER() = takes (0) returns (0) {
+#define macro LOG_2_WRAPPER(fail) = takes (0) returns (0) {
     0x04 calldataload // [x]
-    LOG_2()           // [result]
+    LOG_2(fail)       // [result]
     0x00 mstore
     0x20 0x00 return
 }
@@ -136,15 +136,15 @@
     divWadUp:
         DIV_WAD_UP_WRAPPER(fail)
     rpow:
-        RPOW_WRAPPER()
+        RPOW_WRAPPER(fail)
     expWad:
-        EXP_WAD_WRAPPER()
+        EXP_WAD_WRAPPER(fail)
     lnWad:
-        LN_WAD_WRAPPER()
+        LN_WAD_WRAPPER(fail)
     powWad:
-        POW_WAD_WRAPPER()
+        POW_WAD_WRAPPER(fail)
     sqrt:
         SQRT_WRAPPER()
     logTwo:
-        LOG_2_WRAPPER()
+        LOG_2_WRAPPER(fail)
 }

--- a/test/math/mocks/FixedPointMathWrappers.huff
+++ b/test/math/mocks/FixedPointMathWrappers.huff
@@ -11,53 +11,53 @@
 #define function sqrt(uint256) pure returns(uint256)
 #define function log2(uint256) pure returns(uint256)
 
-#define macro MUL_DIV_DOWN_WRAPPER() = takes (0) returns (0) {
-    0x44 calldataload // [denominator]
-    0x24 calldataload // [y, denominator]
-    0x04 calldataload // [x, y, denominator]
-    MUL_DIV_DOWN()    // [result]
-    0x00 mstore       // []
+#define macro MUL_DIV_DOWN_WRAPPER(fail) = takes (0) returns (0) {
+    0x44 calldataload    // [denominator]
+    0x24 calldataload    // [y, denominator]
+    0x04 calldataload    // [x, y, denominator]
+    MUL_DIV_DOWN(fail)   // [result]
+    0x00 mstore          // []
     0x20 0x00 return
 }
 
-#define macro MUL_DIV_UP_WRAPPER() = takes (0) returns (0) {
-    0x44 calldataload // [denominator]
-    0x24 calldataload // [y, denominator]
-    0x04 calldataload // [x, y, denominator]
-    MUL_DIV_UP()      // [result]
-    0x00 mstore       // []
+#define macro MUL_DIV_UP_WRAPPER(fail) = takes (0) returns (0) {
+    0x44 calldataload  // [denominator]
+    0x24 calldataload  // [y, denominator]
+    0x04 calldataload  // [x, y, denominator]
+    MUL_DIV_UP(fail)   // [result]
+    0x00 mstore        // []
     0x20 0x00 return
 }
 
-#define macro MUL_WAD_DOWN_WRAPPER() = takes (0) returns (0) {
-    0x24 calldataload // [y]
-    0x04 calldataload // [x, y]
-    MUL_WAD_DOWN()    // [result]
-    0x00 mstore       // []
+#define macro MUL_WAD_DOWN_WRAPPER(fail) = takes (0) returns (0) {
+    0x24 calldataload    // [y]
+    0x04 calldataload    // [x, y]
+    MUL_WAD_DOWN(fail)   // [result]
+    0x00 mstore          // []
     0x20 0x00 return
 }
 
-#define macro MUL_WAD_UP_WRAPPER() = takes (0) returns (0) {
-    0x24 calldataload // [y]
-    0x04 calldataload // [x, y]
-    MUL_WAD_UP()      // [result]
-    0x00 mstore       // []
+#define macro MUL_WAD_UP_WRAPPER(fail) = takes (0) returns (0) {
+    0x24 calldataload  // [y]
+    0x04 calldataload  // [x, y]
+    MUL_WAD_UP(fail)   // [result]
+    0x00 mstore        // []
     0x20 0x00 return
 }
 
-#define macro DIV_WAD_DOWN_WRAPPER() = takes (0) returns (0) {
-    0x24 calldataload // [y]
-    0x04 calldataload // [x, y]
-    DIV_WAD_DOWN()    // [result]
-    0x00 mstore       // []
+#define macro DIV_WAD_DOWN_WRAPPER(fail) = takes (0) returns (0) {
+    0x24 calldataload    // [y]
+    0x04 calldataload    // [x, y]
+    DIV_WAD_DOWN(fail)   // [result]
+    0x00 mstore          // []
     0x20 0x00 return
 }
 
-#define macro DIV_WAD_UP_WRAPPER() = takes (0) returns (0) {
-    0x24 calldataload // [y]
-    0x04 calldataload // [x, y]
-    DIV_WAD_UP()      // [result]
-    0x00 mstore       // []
+#define macro DIV_WAD_UP_WRAPPER(fail) = takes (0) returns (0) {
+    0x24 calldataload  // [y]
+    0x04 calldataload  // [x, y]
+    DIV_WAD_UP(fail)   // [result]
+    0x00 mstore        // []
     0x20 0x00 return
 }
 
@@ -121,20 +121,20 @@
     dup1 __FUNC_SIG(sqrt)       eq sqrt       jumpi
     dup1 __FUNC_SIG(log2)       eq logTwo     jumpi
 
-    0x00 0x00 revert
-    
+    fail:
+        0x00 0x00 revert
     mulDivDown:
-        MUL_DIV_DOWN_WRAPPER()
+        MUL_DIV_DOWN_WRAPPER(fail)
     mulDivUp:
-        MUL_DIV_UP_WRAPPER()
+        MUL_DIV_UP_WRAPPER(fail)
     mulWadDown:
-        MUL_WAD_DOWN_WRAPPER()
+        MUL_WAD_DOWN_WRAPPER(fail)
     mulWadUp:
-        MUL_WAD_UP_WRAPPER()
+        MUL_WAD_UP_WRAPPER(fail)
     divWadDown:
-        DIV_WAD_DOWN_WRAPPER()
+        DIV_WAD_DOWN_WRAPPER(fail)
     divWadUp:
-        DIV_WAD_UP_WRAPPER()
+        DIV_WAD_UP_WRAPPER(fail)
     rpow:
         RPOW_WRAPPER()
     expWad:


### PR DESCRIPTION
# Overview

Optimizes `FixedPointMath` macros.

### Checklist
- [x] `mulDivDown`
- [x] `mulDivUp`
- [x] `rpow`

### Current gas difference*
*Manually retrieved Huff macro gas costs from the debugger- could've missed / added an op's cost here or there. Will do a more thorough diff later. Data collected post optimization of `mulDivDown` & `mulDivUp`.
![Screenshot from 2022-07-19 19-05-35](https://user-images.githubusercontent.com/8406232/179863624-72e3fc75-68c9-4802-ab12-6faa551b4554.png)

