### PR TITLE
update: `LibBit` macro names

### DIFF
--- a/src/utils/LibBit.huff
+++ b/src/utils/LibBit.huff
@@ -10,12 +10,12 @@
 #define constant B = 0xffffffffffffffff
 #define constant C = 0xffffffff
 
-#define constant MSB_DEBRUIJN = 0x0009010a0d15021d0b0e10121619031e080c141c0f111807131b17061a05041f
-#define constant LSB_DEBRUIJN = 0x00011c021d0e18031e16140f191104081f1b0d17151310071a0c12060b050a09
+#define constant FLS_DEBRUIJN = 0x0009010a0d15021d0b0e10121619031e080c141c0f111807131b17061a05041f
+#define constant FFS_DEBRUIJN = 0x00011c021d0e18031e16140f191104081f1b0d17151310071a0c12060b050a09
 
 /// @dev Returns the index of the most significant bit of `x`.
 ///      If `x` is zero, returns 256.
-#define macro MSB() = takes (1) returns (1) {
+#define macro FLS() = takes (1) returns (1) {
     // Input stack:   [x]
 
     dup1 iszero    // [x == 0, x]
@@ -57,7 +57,7 @@
     __RIGHTPAD(0x07c4acdd) // [0x07c4acdd (right padded), x, r]
     mul                    // [x * 0x07c4acdd, r]
     0xFB shr               // [(x * 0x07c4acdd) >> 0xFB, r]
-    [MSB_DEBRUIJN] swap1   // [(x * 0x07c4acdd) >> 0xFB, debruijn_lookup, r]
+    [FLS_DEBRUIJN] swap1   // [(x * 0x07c4acdd) >> 0xFB, debruijn_lookup, r]
     byte                   // [b, r]
     or                     // [b | r]
 
@@ -66,7 +66,7 @@
 
 /// @dev Returns the index of the least significant bit of `x`.
 /// If `x` is zero, returns 256.
-#define macro LSB() = takes (1) returns (1) {
+#define macro FFS() = takes (1) returns (1) {
     // Input stack:   [x]
 
     dup1 iszero    // [x == 0, x]
@@ -100,7 +100,7 @@
     __RIGHTPAD(0x077cb531) // [0x077cb531..., x >> r, r]
     mul                    // [(x >> r) * 0x077cb531, r]
     0xFB shr               // [(x * 0x077cb531) >> 0xFB, r]
-    [LSB_DEBRUIJN] swap1   // [(x * 0x077cb531) >> 0xFB, debruijn_lookup, r]
+    [FFS_DEBRUIJN] swap1   // [(x * 0x077cb531) >> 0xFB, debruijn_lookup, r]
     byte                   // [b, r]
     or                     // [b | r]
 
@@ -143,9 +143,9 @@
     // Return stack:  [c]
 }
 
-#define test MSB() = {
+#define test FLS() = {
     0xFF 0x03 shl
-    MSB()
+    FLS()
 
     0x0a eq succeed jumpi
     0x00 dup1 revert
@@ -153,9 +153,9 @@
     succeed:
 }
 
-#define test LSB() = {
+#define test FFS() = {
     0xFF 0x03 shl
-    LSB()
+    FFS()
 
     0x03 eq succeed jumpi
     0x00 dup1 revert

--- a/test/utils/LibBit.t.sol
+++ b/test/utils/LibBit.t.sol
@@ -5,8 +5,8 @@ import "foundry-huff/HuffDeployer.sol";
 import "forge-std/Test.sol";
 
 interface ILibBit {
-	function lsb(uint256) external pure returns (uint256);
-	function msb(uint256) external pure returns (uint256);
+	function ffs(uint256) external pure returns (uint256);
+	function fls(uint256) external pure returns (uint256);
 	function popCount(uint256) external pure returns (uint256);
 }
 
@@ -20,31 +20,31 @@ contract LibBitTest is Test {
         lib = ILibBit(HuffDeployer.deploy_with_code("utils/LibBit", wrapper_code));
     }
 
-    function testFuzzMSB() public {
+    function testFuzzFLS() public {
         for (uint256 i = 1; i < 255; i++) {
-            assertEq(lib.msb((1 << i) - 1), i - 1);
-            assertEq(lib.msb((1 << i)), i);
-            assertEq(lib.msb((1 << i) + 1), i);
+            assertEq(lib.fls((1 << i) - 1), i - 1);
+            assertEq(lib.fls((1 << i)), i);
+            assertEq(lib.fls((1 << i) + 1), i);
         }
-        assertEq(lib.msb(0), 256);
+        assertEq(lib.fls(0), 256);
     }
 
-    function testMSB() public {
-        assertEq(lib.msb(0xff << 3), 10);
+    function testFLS() public {
+        assertEq(lib.fls(0xff << 3), 10);
     }
 
-    function testFuzzLSB() public {
+    function testFuzzFFS() public {
         uint256 brutalizer = uint256(keccak256(abi.encode(address(this), block.timestamp)));
         for (uint256 i = 0; i < 256; i++) {
-            assertEq(lib.lsb(1 << i), i);
-            assertEq(lib.lsb(type(uint256).max << i), i);
-            assertEq(lib.lsb((brutalizer | 1) << i), i);
+            assertEq(lib.ffs(1 << i), i);
+            assertEq(lib.ffs(type(uint256).max << i), i);
+            assertEq(lib.ffs((brutalizer | 1) << i), i);
         }
-        assertEq(lib.lsb(0), 256);
+        assertEq(lib.ffs(0), 256);
     }
 
-    function testLSB() public {
-        assertEq(lib.lsb(0xff << 3), 3);
+    function testFFS() public {
+        assertEq(lib.ffs(0xff << 3), 3);
     }
 
     function testFuzzPopCount(uint256 x) public {

--- a/test/utils/mocks/LibBitWrappers.huff
+++ b/test/utils/mocks/LibBitWrappers.huff
@@ -1,18 +1,18 @@
-#define function msb(uint256) pure returns (uint256)
-#define function lsb(uint256) pure returns (uint256)
+#define function fls(uint256) pure returns (uint256)
+#define function ffs(uint256) pure returns (uint256)
 #define function popCount(uint256) pure returns (uint256)
 
-#define macro MSB_WRAPPER() = {
+#define macro FLS_WRAPPER() = {
     0x04 calldataload
-    MSB()
+    FLS()
 
     0x00 mstore
     0x20 0x00 return
 }
 
-#define macro LSB_WRAPPER() = {
+#define macro FFS_WRAPPER() = {
     0x04 calldataload
-    LSB()
+    FFS()
 
     0x00 mstore
     0x20 0x00 return
@@ -28,16 +28,16 @@
 
 #define macro MAIN() = {
     pc calldataload 0xE0 shr
-    dup1 __FUNC_SIG(msb)      eq msb       jumpi
-    dup1 __FUNC_SIG(lsb)      eq lsb       jumpi
+    dup1 __FUNC_SIG(fls)      eq fls       jumpi
+    dup1 __FUNC_SIG(ffs)      eq ffs       jumpi
     dup1 __FUNC_SIG(popCount) eq pop_count jumpi
 
     0x00 dup1 revert
 
-    msb:
-        MSB_WRAPPER()
-    lsb:
-        LSB_WRAPPER()
+    fls:
+        FLS_WRAPPER()
+    ffs:
+        FFS_WRAPPER()
     pop_count:
         POP_COUNT_WRAPPER()
 }


### PR DESCRIPTION
# Overview

Updates macro names in `LibBit` in accordance w/ Solady's function name changes.

### Name Updates
`MSB` -> `FLS`
`LSB` -> `FFS`