### PR TITLE
fix: teeny tiny bug

### DIFF
--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -570,7 +570,7 @@
     dup1 __FUNC_SIG(approve)            eq approveJump          jumpi
 
     // Bubble up to the parent macro
-    no_match jumpi
+    no_match jump
 
     allowanceJump:
         ALLOWANCE()


### PR DESCRIPTION
I believe before this fix if this ctrct were called with calldata == "" the jumpi would evaluate false and roll into ALLOWANCE() or maybe just die because of missing stack element?  not sure. either way i think it sb `jump`