### PR TITLE
Fix huffconfig address

### DIFF
--- a/test/utils/TSOwnable.t.sol
+++ b/test/utils/TSOwnable.t.sol
@@ -13,7 +13,7 @@ interface TSOwnable {
 
 contract TSOwnableTest is Test {
     TSOwnable tsOwnable;
-    address immutable huffConfig = 0x18669eb6c7dFc21dCdb787fEb4B3F1eBb3172400;
+    address immutable huffConfig = 0xFEfC6BAF87cF3684058D62Da40Ff3A795946Ab06;
 
     function setUp() public {
         // Deploy TSOwnable

--- a/test/utils/TSOwnable.t.sol
+++ b/test/utils/TSOwnable.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.15;
 
-import "foundry-huff/HuffDeployer.sol";
+import "foundry-huff/HuffConfig.sol";
 import "forge-std/Test.sol";
 
 interface TSOwnable {
@@ -13,14 +13,14 @@ interface TSOwnable {
 
 contract TSOwnableTest is Test {
     TSOwnable tsOwnable;
-    address immutable huffConfig = 0xFEfC6BAF87cF3684058D62Da40Ff3A795946Ab06;
+    address huffConfig;
 
     function setUp() public {
         // Deploy TSOwnable
         string memory wrapper_code = vm.readFile("test/utils/mocks/TSOwnableWrappers.huff");
+        huffConfig = address(new HuffConfig());
         tsOwnable = TSOwnable(
-            HuffDeployer
-                .config()
+            HuffConfig(huffConfig)
                 .with_code(wrapper_code)
                 .deploy("utils/TSOwnable")
         );


### PR DESCRIPTION
Ownable tests were not passing locally because the huffConfig address wasn't the correct one.

This is because this function:
https://github.com/huff-language/foundry-huff/blob/eb9ea316389e8bd580f92908b8454399401d0316/src/HuffDeployer.sol#L10-L12
returns a new HuffConfig each it's called. For a long-term fix I would propose to apply the library to a config contract instead of creating one each time a function from the lib is called.

Here is a similar issue: https://github.com/huff-language/foundry-huff/pull/24