### PR TITLE
Fix ternary tests and optimize TERNARY macro

### DIFF
--- a/src/utils/Ternary.huff
+++ b/src/utils/Ternary.huff
@@ -21,15 +21,13 @@
 
 /// @notice Ternary
 /// @notice In shorthand, this is `condition ? x : y`, where the input stack is [condition, x, y]
+/// @dev ((x ^ y) * condition) ^ y
 #define macro TERNARY() = takes(3) returns(1) {
     // Input Stack: [condition, x, y]
+    swap1           // [x, condition, y]
+    dup3            // [y, x, condition, y]
+    xor mul xor     // [((x ^ y) * condition) ^ y]
     // Output Stack: [condition ? x : y]
-
-    // If the condition is false, jump and pop
-    iszero __Utils_Misc__ternaryNoSwap jumpi
-        swap1
-    __Utils_Misc__ternaryNoSwap:
-        pop
 }
 
 // TESTS

--- a/src/utils/Ternary.huff
+++ b/src/utils/Ternary.huff
@@ -24,7 +24,7 @@
     // Output Stack: [condition ? x : y]
 
     // If the condition is false, jump and pop
-    __Utils_Misc__ternaryNoSwap iszero jumpi
+    iszero __Utils_Misc__ternaryNoSwap jumpi
         swap1
     __Utils_Misc__ternaryNoSwap:
         pop
@@ -35,13 +35,13 @@
 /// @notice Tests the NOT_TERNARY() macro
 #define test TEST_NOT_TERNARY() = {
     // Test false should return the first element
-    0x00 0x01 0x02 NOT_TERNARY()
+    0x02 0x01 0x00 NOT_TERNARY()
     0x01 eq worked jumpi
         0x00 0x00 revert
     worked:
 
     // Test true should return the second element
-    0x01 0x01 0x02 NOT_TERNARY()
+    0x02 0x01 0x01 NOT_TERNARY()
     0x02 eq worked_again jumpi
         0x00 0x00 revert
     worked_again:
@@ -50,13 +50,15 @@
 /// @notice Tests the TERNARY() macro
 #define test TEST_TERNARY() = {
     // Test true should return the first element
-    0x01 0x01 0x02 NOT_TERNARY()
+    // 1 ? 1 : 2 == 1
+    0x02 0x01 0x01 TERNARY()
     0x01 eq worked jumpi
         0x00 0x00 revert
     worked:
 
     // Test false should return the second element
-    0x00 0x01 0x02 NOT_TERNARY()
+    // 0 ? 1 : 2 == 2
+    0x02 0x01 0x00 TERNARY()
     0x02 eq worked_again jumpi
         0x00 0x00 revert
     worked_again:

--- a/src/utils/Ternary.huff
+++ b/src/utils/Ternary.huff
@@ -5,16 +5,18 @@
 
 
 /// @notice Not Ternary
-/// @notice In shorthand, this is `!condition ? x : y`, where the input stack is [!condition, x, y]
+/// @notice In shorthand, this is `!condition ? x : y`, where the input stack is [condition, x, y]
 #define macro NOT_TERNARY() = takes(3) returns(1) {
-    // Input Stack: [!condition, x, y]
-    // Output Stack: [!condition ? x : y]
+    // Input Stack: [condition, x, y]
 
     // If the condition is true, jump and pop
     __Utils_Misc__ternaryNoSwap jumpi
-        swap1
+        swap1       // [y, x]
     __Utils_Misc__ternaryNoSwap:
+        // Stack: condition ? [y, x] : [x, y]
         pop
+
+    // Output Stack: [condition ? y : x]
 }
 
 /// @notice Ternary

--- a/src/utils/Ternary.huff
+++ b/src/utils/Ternary.huff
@@ -13,7 +13,7 @@
     __Utils_Misc__ternaryNoSwap jumpi
         swap1       // [y, x]
     __Utils_Misc__ternaryNoSwap:
-        // Stack: condition ? [y, x] : [x, y]
+        // Stack: condition ? [x, y] : [y, x]
         pop
 
     // Output Stack: [condition ? y : x]


### PR DESCRIPTION
Old `TERNARY` macro:

```huff
// Input Stack: [condition, x, y]

// If the condition is false, jump and pop
iszero __Utils_Misc__ternaryNoSwap jumpi
    swap1 // [y, x]
__Utils_Misc__ternaryNoSwap:
   // condition ? [y, x] : [x, y]
    pop // condition ? [x] : [y]
```

When the condition is true, the operations are:
`iszero push jumpi swap jumpdest pop` = 23 gas
When it's false:
`iszero push jumpi jumpdest pop` = 20 gas

If we use branchless logic we can get this down to 17 for both cases:
```huff

// Input Stack: [condition, x, y]
swap1           // [x, condition, y]
dup3            // [y, x, condition, y]
xor mul xor     // [((x ^ y) * condition) ^ y]
// Output Stack: [condition ? x : y]
```

`swap1 dup3 xor mul xor` = 17 gas


I don't think it's possible to do the same optimization for the inverse macro `NOT_TERNARY` because you would either need to swap x and y in the formula, adding an additional swap operation, or use iszero. Since that macro is already 3 gas less than the `TERNARY` macro, adding another operation to the branchless version makes it equivalent for one case and more expensive for the other.

For reference, there are two formulae you can use:
```
// condition ? x : y

(x - y) * condition + y
// Required Stack: [x, y, condition, y]
// sub mul add

((x ^ y) * condition) ^ y
// Required Stack: [x, y, condition, y] OR [y, x, condition, y]
// xor mul xor
```

And for the inverse
```
// condition ? y : x

(y - x) * condition + x
// Required Stack: [y, x, condition, x]
// sub mul add

((x ^ y) * condition) ^ x
// Required Stack: [x, y, condition, x] OR [y, x, condition, x]
// xor mul xor
```

