### PR TITLE
easier inheritance for ERC20.huff

### DIFF
--- a/test/auth/Auth.t.sol
+++ b/test/auth/Auth.t.sol
@@ -56,10 +56,17 @@ contract AuthTest is Test, NonMatchingSelectorsHelper {
   /// @notice Test that a non-matching signature reverts
     function testNonMatchingSelector(bytes32 callData) public {
         bytes4[] memory func_selectors = new bytes4[](6);
+<<<<<<< HEAD
         func_selectors[0] = Auth.setOwner.selector;
         func_selectors[1] = Auth.setAuthority.selector;
         func_selectors[2] = Auth.owner.selector;
         func_selectors[3] = Auth.authority.selector;
+=======
+        func_selectors[0] = bytes4(hex"13af4035");
+        func_selectors[1] = bytes4(hex"7a9e5e4b");
+        func_selectors[2] = bytes4(hex"8da5cb5b");
+        func_selectors[3] = bytes4(hex"bf7e214f");
+>>>>>>> 8910c1f (added non matching selectors in auth tests)
 
         bool success = nonMatchingSelectorHelper(
             func_selectors,

--- a/test/auth/Auth.t.sol
+++ b/test/auth/Auth.t.sol
@@ -57,16 +57,22 @@ contract AuthTest is Test, NonMatchingSelectorsHelper {
     function testNonMatchingSelector(bytes32 callData) public {
         bytes4[] memory func_selectors = new bytes4[](6);
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
         func_selectors[0] = Auth.setOwner.selector;
         func_selectors[1] = Auth.setAuthority.selector;
         func_selectors[2] = Auth.owner.selector;
         func_selectors[3] = Auth.authority.selector;
+<<<<<<< HEAD
 =======
         func_selectors[0] = bytes4(hex"13af4035");
         func_selectors[1] = bytes4(hex"7a9e5e4b");
         func_selectors[2] = bytes4(hex"8da5cb5b");
         func_selectors[3] = bytes4(hex"bf7e214f");
 >>>>>>> 8910c1f (added non matching selectors in auth tests)
+=======
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
 
         bool success = nonMatchingSelectorHelper(
             func_selectors,

--- a/test/auth/Owned.t.sol
+++ b/test/auth/Owned.t.sol
@@ -31,6 +31,7 @@ contract OwnedTest is Test, NonMatchingSelectorsHelper {
     function testNonMatchingSelector(bytes32 callData) public {
         bytes4[] memory func_selectors = new bytes4[](2);
 <<<<<<< HEAD
+<<<<<<< HEAD
         func_selectors[0] = Owned.setOwner.selector;
         func_selectors[1] = Owned.owner.selector;
 
@@ -51,7 +52,12 @@ contract OwnedTest is Test, NonMatchingSelectorsHelper {
 
         // bytes4 func_selector = bytes4(callData << 0xe0);
         // the above will always return 0 because after shifting all left bits are 00000000
+=======
+        func_selectors[0] = Owned.setOwner.selector;
+        func_selectors[1] = Owned.owner.selector;
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
 
+        
         bool success = nonMatchingSelectorHelper(
             func_selectors,
             callData,

--- a/test/auth/Owned.t.sol
+++ b/test/auth/Owned.t.sol
@@ -30,6 +30,7 @@ contract OwnedTest is Test, NonMatchingSelectorsHelper {
   /// @notice Test that a non-matching selector reverts
     function testNonMatchingSelector(bytes32 callData) public {
         bytes4[] memory func_selectors = new bytes4[](2);
+<<<<<<< HEAD
         func_selectors[0] = Owned.setOwner.selector;
         func_selectors[1] = Owned.owner.selector;
 
@@ -42,6 +43,24 @@ contract OwnedTest is Test, NonMatchingSelectorsHelper {
         assert(!success);
     }
 
+=======
+        func_selectors[0] = bytes4(hex"13af4035");
+        func_selectors[1] = bytes4(hex"8da5cb5b");
+
+        // the above would never fail as if a non matching selector
+
+        // bytes4 func_selector = bytes4(callData << 0xe0);
+        // the above will always return 0 because after shifting all left bits are 00000000
+
+        bool success = nonMatchingSelectorHelper(
+            func_selectors,
+            callData,
+            address(owner)
+        );
+        assert(!success);
+    }
+
+>>>>>>> 8910c1f (added non matching selectors in auth tests)
   function testGetOwner() public {
     assertEq(OWNER, owner.owner());
   }

--- a/test/auth/RolesAuthority.t.sol
+++ b/test/auth/RolesAuthority.t.sol
@@ -45,6 +45,7 @@ contract RolesAuthorityTest is Test, NonMatchingSelectorsHelper {
 
   /// @notice Test that a non-matching selector reverts
     function testNonMatchingSelector(bytes32 callData) public {
+<<<<<<< HEAD
         bytes4[] memory func_selectors = new bytes4[](6);
         func_selectors[0] = RolesAuthority.hasRole.selector;
         func_selectors[1] = RolesAuthority.doesRoleHaveCapability.selector;
@@ -52,6 +53,11 @@ contract RolesAuthorityTest is Test, NonMatchingSelectorsHelper {
         func_selectors[3] = RolesAuthority.setPublicCapability.selector;
         func_selectors[4] = RolesAuthority.setRoleCapability.selector;
         func_selectors[5] = RolesAuthority.setUserRole.selector;
+=======
+        bytes4[] memory func_selectors = new bytes4[](2);
+        func_selectors[0] = bytes4(hex"13af4035");
+        func_selectors[1] = bytes4(hex"8da5cb5b");
+>>>>>>> 8910c1f (added non matching selectors in auth tests)
 
         bool success = nonMatchingSelectorHelper(
             func_selectors,

--- a/test/auth/RolesAuthority.t.sol
+++ b/test/auth/RolesAuthority.t.sol
@@ -46,6 +46,9 @@ contract RolesAuthorityTest is Test, NonMatchingSelectorsHelper {
   /// @notice Test that a non-matching selector reverts
     function testNonMatchingSelector(bytes32 callData) public {
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
         bytes4[] memory func_selectors = new bytes4[](6);
         func_selectors[0] = RolesAuthority.hasRole.selector;
         func_selectors[1] = RolesAuthority.doesRoleHaveCapability.selector;
@@ -53,11 +56,14 @@ contract RolesAuthorityTest is Test, NonMatchingSelectorsHelper {
         func_selectors[3] = RolesAuthority.setPublicCapability.selector;
         func_selectors[4] = RolesAuthority.setRoleCapability.selector;
         func_selectors[5] = RolesAuthority.setUserRole.selector;
+<<<<<<< HEAD
 =======
         bytes4[] memory func_selectors = new bytes4[](2);
         func_selectors[0] = bytes4(hex"13af4035");
         func_selectors[1] = bytes4(hex"8da5cb5b");
 >>>>>>> 8910c1f (added non matching selectors in auth tests)
+=======
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
 
         bool success = nonMatchingSelectorHelper(
             func_selectors,

--- a/test/test-utils/NonMatchingSelectorHelper.sol
+++ b/test/test-utils/NonMatchingSelectorHelper.sol
@@ -3,15 +3,35 @@ pragma solidity ^0.8.15;
 
 import "forge-std/Test.sol";
 
+<<<<<<< HEAD
 abstract contract NonMatchingSelectorsHelper {
     /// @dev Expected to return false.
+=======
+/**
+ * expected to fail
+ */
+abstract contract NonMatchingSelectorsHelper {
+>>>>>>> bde0a4d (added helper for testing non matching selectors)
     function nonMatchingSelectorHelper(
         bytes4[] memory func_selectors,
         bytes32 callData,
         address target
     ) internal returns (bool) {
+<<<<<<< HEAD
         bytes4 func_selector = bytes4(callData);
     
+=======
+        bytes4 func_selector;
+        assembly {
+            func_selector := and(
+                callData,
+                0xffffffff00000000000000000000000000000000000000000000000000000000
+            )
+        }
+        console.logBytes4(func_selector);
+        console.logBytes4(func_selectors[0]);
+
+>>>>>>> bde0a4d (added helper for testing non matching selectors)
         for (uint256 i = 0; i < func_selectors.length; i++) {
             if (func_selector == func_selectors[i]) {
                 return false;

--- a/test/test-utils/NonMatchingSelectorHelper.sol
+++ b/test/test-utils/NonMatchingSelectorHelper.sol
@@ -7,6 +7,7 @@ import "forge-std/Test.sol";
 <<<<<<< HEAD
 abstract contract NonMatchingSelectorsHelper {
     /// @dev Expected to return false.
+<<<<<<< HEAD
 =======
 /**
  * expected to fail
@@ -15,6 +16,8 @@ abstract contract NonMatchingSelectorsHelper {
 >>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
 abstract contract NonMatchingSelectorsHelper {
 >>>>>>> bde0a4d (added helper for testing non matching selectors)
+=======
+>>>>>>> 9ecff36 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
     function nonMatchingSelectorHelper(
         bytes4[] memory func_selectors,
         bytes32 callData,

--- a/test/test-utils/NonMatchingSelectorHelper.sol
+++ b/test/test-utils/NonMatchingSelectorHelper.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.15;
 import "forge-std/Test.sol";
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 abstract contract NonMatchingSelectorsHelper {
     /// @dev Expected to return false.
 =======
 /**
  * expected to fail
  */
+=======
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
 abstract contract NonMatchingSelectorsHelper {
 >>>>>>> bde0a4d (added helper for testing non matching selectors)
     function nonMatchingSelectorHelper(
@@ -17,6 +20,7 @@ abstract contract NonMatchingSelectorsHelper {
         bytes32 callData,
         address target
     ) internal returns (bool) {
+<<<<<<< HEAD
 <<<<<<< HEAD
         bytes4 func_selector = bytes4(callData);
     
@@ -32,6 +36,10 @@ abstract contract NonMatchingSelectorsHelper {
         console.logBytes4(func_selectors[0]);
 
 >>>>>>> bde0a4d (added helper for testing non matching selectors)
+=======
+        bytes4 func_selector = bytes4(callData);
+    
+>>>>>>> a2d6ce3 (fixed comments and simplified changes, added all selectors to rolesAuthority test)
         for (uint256 i = 0; i < func_selectors.length; i++) {
             if (func_selector == func_selectors[i]) {
                 return false;

--- a/test/tokens/mocks/ERC20MintableWrappers.huff
+++ b/test/tokens/mocks/ERC20MintableWrappers.huff
@@ -35,25 +35,10 @@
 
 #define macro MAIN() = takes (0) returns (0) {
     0x00 calldataload 0xE0 shr
+    ERC20_MAIN()
 
     dup1 __FUNC_SIG(mint) eq mint jumpi
     dup1 __FUNC_SIG(burn) eq burn jumpi
-
-    dup1 __FUNC_SIG(permit) eq permitJump           jumpi
-    dup1 __FUNC_SIG(nonces) eq noncesJump           jumpi
-
-    dup1 __FUNC_SIG(name) eq nameJump jumpi
-    dup1 __FUNC_SIG(symbol) eq symbolJump jumpi
-    dup1 __FUNC_SIG(decimals) eq decimalsJump jumpi
-    dup1 __FUNC_SIG(DOMAIN_SEPARATOR) eq domainSeparatorJump jumpi
-
-    dup1 __FUNC_SIG(totalSupply) eq totalSupplyJump jumpi
-    dup1 __FUNC_SIG(balanceOf) eq balanceOfJump jumpi
-    dup1 __FUNC_SIG(allowance) eq allowanceJump jumpi
-
-    dup1 __FUNC_SIG(transfer)           eq transferJump         jumpi
-    dup1 __FUNC_SIG(transferFrom)       eq transferFromJump     jumpi
-    dup1 __FUNC_SIG(approve)            eq approveJump          jumpi
 
     // Revert if no selector matches
     0x00 0x00 revert
@@ -62,28 +47,4 @@
         MINT()
     burn:
         BURN()
-    allowanceJump:
-        ALLOWANCE()
-    approveJump:
-        APPROVE()
-    balanceOfJump:
-        BALANCE_OF()
-    decimalsJump:
-        DECIMALS()
-    domainSeparatorJump:
-        DOMAIN_SEPARATOR()
-    nameJump:
-        NAME()
-    noncesJump:
-        NONCES()
-    permitJump:
-        PERMIT()
-    symbolJump:
-        SYMBOL()
-    totalSupplyJump:
-        TOTAL_SUPPLY()
-    transferFromJump:
-        TRANSFER_FROM()
-    transferJump:
-        TRANSFER()
 }

--- a/test/utils/TSOwnable.t.sol
+++ b/test/utils/TSOwnable.t.sol
@@ -18,11 +18,19 @@ contract TSOwnableTest is Test {
     function setUp() public {
         // Deploy TSOwnable
         string memory wrapper_code = vm.readFile("test/utils/mocks/TSOwnableWrappers.huff");
+<<<<<<< HEAD
         huffConfig = address(new HuffConfig());
         tsOwnable = TSOwnable(
             HuffConfig(huffConfig)
                 .with_code(wrapper_code)
                 .deploy("utils/TSOwnable")
+=======
+        huffConfig = address(HuffDeployer.config());
+        tsOwnable = TSOwnable(
+            HuffConfig(huffConfig).with_code(wrapper_code).deploy(
+                "utils/TSOwnable"
+            )
+>>>>>>> e9afee2 (fixed failing test)
         );
     }
 


### PR DESCRIPTION
Changing `no-match jumpi` to `no-match jump` in ERC20.huff function dispatcher leaves the shifted function sig on the stack for contracts inheriting it which can use it after the `no-match` JUMPDEST. This way, importing (wrapping) contracts only have to add:
```
0x00 calldataload 0xE0 shr
ERC20_MAIN()
```
to the start of their MAIN() macro then add their specific function below it rather than copying all of ERC20.huff dispatch macro.
