### PR TITLE
use ERC20_MAIN macro

### DIFF
--- a/test/tokens/mocks/ERC20MintableWrappers.huff
+++ b/test/tokens/mocks/ERC20MintableWrappers.huff
@@ -34,11 +34,12 @@
 }
 
 #define macro MAIN() = takes (0) returns (0) {
-    0x00 calldataload 0xE0 shr
-    ERC20_MAIN()
+    0x00 calldataload 0xE0 shr              // [sig]
 
-    dup1 __FUNC_SIG(mint) eq mint jumpi
-    dup1 __FUNC_SIG(burn) eq burn jumpi
+    dup1 __FUNC_SIG(mint) eq mint jumpi     // [sig]
+    dup1 __FUNC_SIG(burn) eq burn jumpi     // [sig]
+
+    ERC20_MAIN()                            // [sig]
 
     // Revert if no selector matches
     0x00 0x00 revert

--- a/test/tokens/mocks/ERC20MintableWrappers.huff
+++ b/test/tokens/mocks/ERC20MintableWrappers.huff
@@ -35,25 +35,10 @@
 
 #define macro MAIN() = takes (0) returns (0) {
     0x00 calldataload 0xE0 shr
+    ERC20_MAIN()
 
     dup1 __FUNC_SIG(mint) eq mint jumpi
     dup1 __FUNC_SIG(burn) eq burn jumpi
-
-    dup1 __FUNC_SIG(permit) eq permitJump           jumpi
-    dup1 __FUNC_SIG(nonces) eq noncesJump           jumpi
-
-    dup1 __FUNC_SIG(name) eq nameJump jumpi
-    dup1 __FUNC_SIG(symbol) eq symbolJump jumpi
-    dup1 __FUNC_SIG(decimals) eq decimalsJump jumpi
-    dup1 __FUNC_SIG(DOMAIN_SEPARATOR) eq domainSeparatorJump jumpi
-
-    dup1 __FUNC_SIG(totalSupply) eq totalSupplyJump jumpi
-    dup1 __FUNC_SIG(balanceOf) eq balanceOfJump jumpi
-    dup1 __FUNC_SIG(allowance) eq allowanceJump jumpi
-
-    dup1 __FUNC_SIG(transfer)           eq transferJump         jumpi
-    dup1 __FUNC_SIG(transferFrom)       eq transferFromJump     jumpi
-    dup1 __FUNC_SIG(approve)            eq approveJump          jumpi
 
     // Revert if no selector matches
     0x00 0x00 revert
@@ -62,28 +47,4 @@
         MINT()
     burn:
         BURN()
-    allowanceJump:
-        ALLOWANCE()
-    approveJump:
-        APPROVE()
-    balanceOfJump:
-        BALANCE_OF()
-    decimalsJump:
-        DECIMALS()
-    domainSeparatorJump:
-        DOMAIN_SEPARATOR()
-    nameJump:
-        NAME()
-    noncesJump:
-        NONCES()
-    permitJump:
-        PERMIT()
-    symbolJump:
-        SYMBOL()
-    totalSupplyJump:
-        TOTAL_SUPPLY()
-    transferFromJump:
-        TRANSFER_FROM()
-    transferJump:
-        TRANSFER()
 }


### PR DESCRIPTION
Changing `no-match jumpi` to `no-match jump` in ERC20.huff function dispatcher leaves the shifted function sig on the stack for contracts inheriting it which can use it after the `no-match` JUMPDEST. This way, importing (wrapping) contracts only have to add:

```
0x00 calldataload 0xE0 shr
ERC20_MAIN()
```

to the start of their MAIN() macro then add their specific function below it rather than copying all of ERC20.huff dispatch macro.

