### PR TITLE
fix: ERC20.decimals() signature to return uint8

### DIFF
--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -26,7 +26,7 @@
 #define event Transfer(address, address, uint256)
 
 // Metadata
-#define function decimals() nonpayable returns (uint256)
+#define function decimals() nonpayable returns (uint8)
 #define function name() nonpayable returns (string)
 #define function symbol() nonpayable returns (string)
 


### PR DESCRIPTION
According to the EIP decimals should returns a uint8; https://eips.ethereum.org/EIPS/eip-20#decimals