### PR TITLE
Optimization (Trigonometry): remove unnecessary iszero iszero sequence

### DIFF
--- a/src/math/Trigonometry.huff
+++ b/src/math/Trigonometry.huff
@@ -94,8 +94,7 @@
 
     dup4                  // [angle, is_odd_quadrant, index, interp, angle]
     [QUADRANT_HIGH_MASK]  // [QUADRANT_HIGH_MASK, angle, is_odd_quadrant, index, interp, angle]
-    and                   // [QUADRANT_HIGH_MASK & angle, is_odd_quadrant, index, interp, angle]
-    iszero iszero         // [is_negative_quadrant, is_odd_quadrant, index, interp, angle]
+    and                   // [is_negative_quadrant, is_odd_quadrant, index, interp, angle]
 
     // Jump past updating the index if `is_odd_quadrant` is true
     dup2 is_odd_q jumpi   // [is_negative_quadrant, is_odd_quadrant, index, interp, angle]


### PR DESCRIPTION
We can save 6 gas units by simplifying the code.

Original definition:
`is_negative_quadrant = iszero(iszero(QUADRANT_HIGH_MASK & angle))`

This value is used only once, as a condition for a `jumpi`, after being consumed by another `iszero` instruction.
https://github.com/huff-language/huffmate/blob/4e2c9bd3412ab8cc65f6ceadafc01a1ff1815796/src/math/Trigonometry.huff#L155-L156

Thus, the condition effectively becomes:
`condition = iszero(iszero(iszero(QUADRANT_HIGH_MASK & angle)))`
which simplifies to:
`condition = iszero(QUADRANT_HIGH_MASK & angle)`

This achieves the same logical outcome while reducing gas usage.
