### PR TITLE
Fix `forge test` failing

### DIFF
--- a/src/math/SafeMath.huff
+++ b/src/math/SafeMath.huff
@@ -4,8 +4,6 @@
 /// @notice Math module over Solidity's arithmetic operations with safety checks
 /// @notice Adapted from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/math/SafeMath.sol)
 
-#include "../utils/Errors.huff"
-
 // Interface
 #define function safeAdd(uint256,uint256) pure returns (uint256)
 #define function safeSub(uint256,uint256) pure returns (uint256)

--- a/src/proxies/Clones.huff
+++ b/src/proxies/Clones.huff
@@ -12,7 +12,6 @@
 /// @notice Adapted from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/Clones.sol)
 
 #include "./ERC1967Upgrade.huff"
-#include "../utils/CommonErrors.huff"
 
 // BEFORE ADDRESS
 //--------------------------------------------------------------------------------//

--- a/src/proxies/ERC1967Upgrade.huff
+++ b/src/proxies/ERC1967Upgrade.huff
@@ -5,6 +5,7 @@
 /// @dev This abstract contract provides getters and event emitting update functions for https://eips.ethereum.org/EIPS/eip-1967[EIP1967] slots.
 /// @notice Adapted from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/ERC1967/ERC1967Upgrade.sol)
 
+#include "../utils/Errors.huff"
 #include "../utils/CommonErrors.huff"
 
 // Function Definitions

--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -70,7 +70,7 @@
     [INITIAL_DOMAIN_SEPARATOR] sstore       // []
     
     // Copy the runtime bytecode with constructor argument concatenated.
-    0x67                                    // [offset] - constructor code size
+    0x66                                    // [offset] - constructor code size
     dup1                                    // [offset, offset]
     codesize                                // [total_size, offset, offset]
     sub                                     // [runtime_size, offset]

--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -69,7 +69,7 @@
     [INITIAL_DOMAIN_SEPARATOR] sstore       // []
     
     // Copy the runtime bytecode with constructor argument concatenated.
-    0x66                                    // [offset] - constructor code size
+    __codesize(CONSTRUCTOR)                 // [offset] - constructor code size
     dup1                                    // [offset, offset]
     codesize                                // [total_size, offset, offset]
     sub                                     // [runtime_size, offset]

--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -6,7 +6,6 @@
 /// @notice Adapted from Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC20.sol)
 
 // Imports
-#include "../utils/Errors.huff"
 #include "../auth/NonPayable.huff"
 #include "../data-structures/Hashmap.huff"
 

--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -243,24 +243,6 @@
     [BALANCE_SLOT] STORE_ELEMENT_FROM_KEYS(0x00)        // [value, from, to]
 }
 
-/// @notice Approve
-/// @notice Approves an address to spend an amount of tokens on the caller's behalf
-#define macro APPROVE() = takes (0) returns (0) {
-    0x24 calldataload                           // [value]
-    dup1 0x00 mstore                            // [value]
-    0x04 calldataload                           // [to, value]
-    caller                                      // [from, to, value]
-
-    // Emit the approval event.
-    dup2 dup2                                   // [from, to, from, to, value]
-    __EVENT_HASH(APPROVAL_EVENT_SIGNATURE)      // [sig, from, to, from, to, value]
-    0x20 0x00                                   // [0, 32, sig, from, to, from, to, value]
-    log3                                        // [from, to, value]
-
-    // Store the value at slot = keccak256(from . to)
-    STORE_ELEMENT_FROM_KEYS(0x00)
-}
-
 /// @notice Domain Separator
 /// @notice Returns the EIP-712 domain separator
 #define macro DOMAIN_SEPARATOR() = takes (0) returns (0) {

--- a/src/utils/Bytecode.huff
+++ b/src/utils/Bytecode.huff
@@ -4,6 +4,7 @@
 /// @notice Low-level bytecode utilities
 /// @notice Adapted from 0xsequence/sstore2 (https://github.com/0xsequence/sstore2/blob/master/contracts/utils/Bytecode.sol)
 
+#include "./Errors.huff"
 #include "./CommonErrors.huff"
 
 /// @notice Generate a creation code that results on a contract with `_code` as bytecode

--- a/src/utils/CREATE3.huff
+++ b/src/utils/CREATE3.huff
@@ -5,6 +5,7 @@
 /// @notice Deploy to deterministic addresses without an initcode factor
 /// @notice Adapted from Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/CREATE3.sol)
 
+#include "./Errors.huff"
 #include "./CommonErrors.huff"
 
 

--- a/src/utils/CommonErrors.huff
+++ b/src/utils/CommonErrors.huff
@@ -3,7 +3,6 @@
 /// @author asnared <https://github.com/abigger87>
 /// @notice Wrappers for reverting with common error messages
 
-#include "./Errors.huff"
 
 // Error Constants
 #define constant NOT_AUTHORIZED_ERROR = 0x4e4f545f415554484f52495a4544000000000000000000000000000000000000

--- a/src/utils/MerkleDistributor.huff
+++ b/src/utils/MerkleDistributor.huff
@@ -7,6 +7,7 @@
 
 
 // Imports
+#include "./Errors.huff"
 #include "./CommonErrors.huff"
 #include "./MerkleProofLib.huff"
 #include "./Address.huff"

--- a/src/utils/ReentrancyGuard.huff
+++ b/src/utils/ReentrancyGuard.huff
@@ -4,6 +4,7 @@
 /// @notice Gas optimized reentrancy guard for smart contracts.
 /// @notice Adapted from Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/ReentrancyGuard.sol)
 
+#include "./Errors.huff"
 #include "./CommonErrors.huff"
 
 // Interface

--- a/src/utils/Refunded.huff
+++ b/src/utils/Refunded.huff
@@ -4,7 +4,6 @@
 /// @notice Efficient gas refunds distributed through a modifier
 /// @notice Adapted from Zolidity (https://github.com/z0r0z/zolidity/blob/main/src/utils/Refunded.sol)
 
-#include "./Errors.huff"
 #include "./ReentrancyGuard.huff"
 
 /// @notice The base cost of refunding

--- a/src/utils/SSTORE2.huff
+++ b/src/utils/SSTORE2.huff
@@ -5,7 +5,6 @@
 /// @notice Adapted from 0xsequence/sstore2 (https://github.com/0xsequence/sstore2)
 
 #include "./Bytecode.huff"
-#include "./CommonErrors.huff"
 
 #define constant TYPE_UINT_256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 

--- a/test/math/FixedPointMath.t.sol
+++ b/test/math/FixedPointMath.t.sol
@@ -123,7 +123,8 @@ contract FixedPointMathTest is Test {
         assertEq(math.divWadDown(0, 1e18), 0);
     }
 
-    function testFailDivWadDownZeroDenominator() public {
+    function test_RevertWhen_DivWadDownZeroDenominator() public {
+        vm.expectRevert();
         math.divWadDown(1e18, 0);
     }
 
@@ -137,7 +138,8 @@ contract FixedPointMathTest is Test {
         assertEq(math.divWadUp(0, 1e18), 0);
     }
 
-    function testFailDivWadUpZeroDenominator() public {
+    function test_RevertWhen_DivWadUpZeroDenominator() public {
+        vm.expectRevert();
         math.divWadUp(1e18, 0);
     }
 
@@ -162,7 +164,8 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulDivDown(0, 0, 1e18), 0);
     }
 
-    function testFailMulDivDownZeroDenominator() public {
+    function test_RevertWhen_MulDivDownZeroDenominator() public {
+        vm.expectRevert();
         math.mulDivDown(1e18, 1e18, 0);
     }
 
@@ -187,7 +190,8 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulDivUp(0, 0, 1e18), 0);
     }
 
-    function testFailMulDivUpZeroDenominator() public {
+    function test_RevertWhen_MulDivUpZeroDenominator() public {
+        vm.expectRevert();
         math.mulDivUp(1e18, 1e18, 0);
     }
 
@@ -294,12 +298,14 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulWadDown(x, y), (x * y) / 1e18);
     }
 
-    function testFailFuzzMulWadDownOverflow(uint256 x, uint256 y) public {
-        // Ignore cases where x * y does not overflow.
+    function test_RevertWhen_FuzzMulWadDownOverflow(uint256 x, uint256 y) public {
+        // Only test cases where x * y overflows.
+        vm.assume(x != 0);
         unchecked {
-            if ((x * y) / x == y) revert();
+            vm.assume((x * y) / x != y);
         }
 
+        vm.expectRevert();
         math.mulWadDown(x, y);
     }
 
@@ -312,12 +318,14 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulWadUp(x, y), x * y == 0 ? 0 : (x * y - 1) / 1e18 + 1);
     }
 
-    function testFailFuzzMulWadUpOverflow(uint256 x, uint256 y) public {
-        // Ignore cases where x * y does not overflow.
+    function test_RevertWhen_FuzzMulWadUpOverflow(uint256 x, uint256 y) public {
+        // Only test cases where x * y overflows.
+        vm.assume(x != 0);
         unchecked {
-            if ((x * y) / x == y) revert();
+            vm.assume((x * y) / x != y);
         }
 
+        vm.expectRevert();
         math.mulWadUp(x, y);
     }
 
@@ -330,16 +338,19 @@ contract FixedPointMathTest is Test {
         assertEq(math.divWadDown(x, y), (x * 1e18) / y);
     }
 
-    function testFailFuzzDivWadDownOverflow(uint256 x, uint256 y) public {
-        // Ignore cases where x * WAD does not overflow or y is 0.
+    function test_RevertWhen_FuzzDivWadDownOverflow(uint256 x, uint256 y) public {
+        // Only test cases where x * WAD overflows and y is non-zero.
+        vm.assume(y != 0);
         unchecked {
-            if (y == 0 || (x * 1e18) / 1e18 == x) revert();
+            vm.assume((x * 1e18) / 1e18 != x);
         }
 
+        vm.expectRevert();
         math.divWadDown(x, y);
     }
 
-    function testFailFuzzDivWadDownZeroDenominator(uint256 x) public {
+    function test_RevertWhen_FuzzDivWadDownZeroDenominator(uint256 x) public {
+        vm.expectRevert();
         math.divWadDown(x, 0);
     }
 
@@ -352,16 +363,19 @@ contract FixedPointMathTest is Test {
         assertEq(math.divWadUp(x, y), x == 0 ? 0 : (x * 1e18 - 1) / y + 1);
     }
 
-    function testFailFuzzDivWadUpOverflow(uint256 x, uint256 y) public {
-        // Ignore cases where x * WAD does not overflow or y is 0.
+    function test_RevertWhen_FuzzDivWadUpOverflow(uint256 x, uint256 y) public {
+        // Only test cases where x * WAD overflows and y is non-zero.
+        vm.assume(y != 0);
         unchecked {
-            if (y == 0 || (x * 1e18) / 1e18 == x) revert();
+            vm.assume((x * 1e18) / 1e18 != x);
         }
 
+        vm.expectRevert();
         math.divWadUp(x, y);
     }
 
-    function testFailFuzzDivWadUpZeroDenominator(uint256 x) public {
+    function test_RevertWhen_FuzzDivWadUpZeroDenominator(uint256 x) public {
+        vm.expectRevert();
         math.divWadUp(x, 0);
     }
 
@@ -378,20 +392,24 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulDivDown(x, y, denominator), (x * y) / denominator);
     }
 
-    function testFailFuzzMulDivDownOverflow(
+    function test_RevertWhen_FuzzMulDivDownOverflow(
         uint256 x,
         uint256 y,
         uint256 denominator
     ) public {
-        // Ignore cases where x * y does not overflow or denominator is 0.
+        // Only test cases where x * y overflows and denominator is non-zero.
+        vm.assume(denominator != 0);
+        vm.assume(x != 0);
         unchecked {
-            if (denominator == 0 || (x * y) / x == y) revert();
+            vm.assume((x * y) / x != y);
         }
 
+        vm.expectRevert();
         math.mulDivDown(x, y, denominator);
     }
 
-    function testFailFuzzMulDivDownZeroDenominator(uint256 x, uint256 y) public {
+    function test_RevertWhen_FuzzMulDivDownZeroDenominator(uint256 x, uint256 y) public {
+        vm.expectRevert();
         math.mulDivDown(x, y, 0);
     }
 
@@ -408,20 +426,24 @@ contract FixedPointMathTest is Test {
         assertEq(math.mulDivUp(x, y, denominator), x * y == 0 ? 0 : (x * y - 1) / denominator + 1);
     }
 
-    function testFailFuzzMulDivUpOverflow(
+    function test_RevertWhen_FuzzMulDivUpOverflow(
         uint256 x,
         uint256 y,
         uint256 denominator
     ) public {
-        // Ignore cases where x * y does not overflow or denominator is 0.
+        // Only test cases where x * y overflows and denominator is non-zero.
+        vm.assume(denominator != 0);
+        vm.assume(x != 0);
         unchecked {
-            if (denominator == 0 || (x * y) / x == y) revert();
+            vm.assume((x * y) / x != y);
         }
 
+        vm.expectRevert();
         math.mulDivUp(x, y, denominator);
     }
 
-    function testFailFuzzMulDivUpZeroDenominator(uint256 x, uint256 y) public {
+    function test_RevertWhen_FuzzMulDivUpZeroDenominator(uint256 x, uint256 y) public {
+        vm.expectRevert();
         math.mulDivUp(x, y, 0);
     }
 

--- a/test/math/FixedPointMath.t.sol
+++ b/test/math/FixedPointMath.t.sol
@@ -319,11 +319,9 @@ contract FixedPointMathTest is Test {
     }
 
     function test_RevertWhen_FuzzMulWadUpOverflow(uint256 x, uint256 y) public {
-        // Only test cases where x * y overflows.
-        vm.assume(x != 0);
-        unchecked {
-            vm.assume((x * y) / x != y);
-        }
+        // Bound the inputs so x * y is guaranteed to overflow
+        x = bound(x, 2, type(uint256).max);
+        y = bound(y, type(uint256).max / x + 1, type(uint256).max);
 
         vm.expectRevert();
         math.mulWadUp(x, y);
@@ -364,11 +362,9 @@ contract FixedPointMathTest is Test {
     }
 
     function test_RevertWhen_FuzzDivWadUpOverflow(uint256 x, uint256 y) public {
-        // Only test cases where x * WAD overflows and y is non-zero.
-        vm.assume(y != 0);
-        unchecked {
-            vm.assume((x * 1e18) / 1e18 != x);
-        }
+        // Bound the inputs so x * WAD is guaranteed to overflow and y is non-zero
+        x = bound(x, type(uint256).max / 1e18 + 1, type(uint256).max);
+        y = bound(y, 1, type(uint256).max);
 
         vm.expectRevert();
         math.divWadUp(x, y);
@@ -431,12 +427,10 @@ contract FixedPointMathTest is Test {
         uint256 y,
         uint256 denominator
     ) public {
-        // Only test cases where x * y overflows and denominator is non-zero.
-        vm.assume(denominator != 0);
-        vm.assume(x != 0);
-        unchecked {
-            vm.assume((x * y) / x != y);
-        }
+        // Bound the inputs so x * y is guaranteed to overflow and denominator is non-zero
+        x = bound(x, 2, type(uint256).max);
+        denominator = bound(denominator, 1, type(uint256).max);
+        y = bound(y, type(uint256).max / x + 1, type(uint256).max);
 
         vm.expectRevert();
         math.mulDivUp(x, y, denominator);

--- a/test/math/mocks/SafeMathWrappers.huff
+++ b/test/math/mocks/SafeMathWrappers.huff
@@ -1,3 +1,4 @@
+#include "../utils/Errors.huff"
 
 // Wrapper methods (for testing)
 #define macro SAFE_ADD_WRAPPER() = takes (0) returns (0) {

--- a/test/tokens/ERC1155.t.sol
+++ b/test/tokens/ERC1155.t.sol
@@ -1167,6 +1167,10 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
         address from = address(0xABCD);
 
+        // Skip self-transfers: the per-id balance bookkeeping below assumes `to`
+        // and `from` are distinct (a self-transfer leaves `from`'s balance whole).
+        if (to == from) return;
+
         uint256 minLength = min3(ids.length, mintAmounts.length, transferAmounts.length);
 
         uint256[] memory normalizedIds = new uint256[](minLength);

--- a/test/tokens/ERC1155.t.sol
+++ b/test/tokens/ERC1155.t.sol
@@ -163,11 +163,15 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
     /// @dev Setup the testing environment.
     function setUp() public {
         string memory wrappers = vm.readFile("test/tokens/mocks/ERC1155Wrappers.huff");
-        HuffDeployer.config().with_args(bytes.concat(abi.encode("Token"), abi.encode("TKN")));
-        token = ERC1155(HuffDeployer.deploy_with_code("tokens/ERC1155", wrappers));
+        token = ERC1155(
+            HuffDeployer.config()
+                .with_args(bytes.concat(abi.encode("Token"), abi.encode("TKN")))
+                .with_code(wrappers)
+                .deploy("tokens/ERC1155")
+        );
     }
 
-    function invariantMetadata() public {
+    function testMetadataConstant() public {
         assertEq(keccak256(abi.encode(token.name())), keccak256(abi.encode("Token")));
         assertEq(keccak256(abi.encode(token.symbol())), keccak256(abi.encode("TKN")));
     }
@@ -479,28 +483,36 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         assertEq(balances[4], 500);
     }
 
-    function testFailMintToZero() public {
+    function test_RevertWhen_MintToZero() public {
+        vm.expectRevert();
         token.mint(address(0), 1337, 1, "");
     }
 
-    function testFailMintToNonERC155Recipient() public {
-        token.mint(address(new NonERC1155Recipient()), 1337, 1, "");
+    function test_RevertWhen_MintToNonERC155Recipient() public {
+        address to = address(new NonERC1155Recipient());
+        vm.expectRevert();
+        token.mint(to, 1337, 1, "");
     }
 
-    function testFailMintToRevertingERC155Recipient() public {
-        token.mint(address(new RevertingERC1155Recipient()), 1337, 1, "");
+    function test_RevertWhen_MintToRevertingERC155Recipient() public {
+        address to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
+        token.mint(to, 1337, 1, "");
     }
 
-    function testFailMintToWrongReturnDataERC155Recipient() public {
-        token.mint(address(new RevertingERC1155Recipient()), 1337, 1, "");
+    function test_RevertWhen_MintToWrongReturnDataERC155Recipient() public {
+        address to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
+        token.mint(to, 1337, 1, "");
     }
 
-    function testFailBurnInsufficientBalance() public {
+    function test_RevertWhen_BurnInsufficientBalance() public {
         token.mint(address(0xBEEF), 1337, 70, "");
+        vm.expectRevert();
         token.burn(address(0xBEEF), 1337, 100);
     }
 
-    function testFailSafeTransferFromInsufficientBalance() public {
+    function test_RevertWhen_SafeTransferFromInsufficientBalance() public {
         address from = address(0xABCD);
 
         token.mint(from, 1337, 70, "");
@@ -508,35 +520,44 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeTransferFrom(from, address(0xBEEF), 1337, 100, "");
     }
 
-    function testFailSafeTransferFromSelfInsufficientBalance() public {
+    function test_RevertWhen_SafeTransferFromSelfInsufficientBalance() public {
         token.mint(address(this), 1337, 70, "");
+        vm.expectRevert();
         token.safeTransferFrom(address(this), address(0xBEEF), 1337, 100, "");
     }
 
-    function testFailSafeTransferFromToZero() public {
+    function test_RevertWhen_SafeTransferFromToZero() public {
         token.mint(address(this), 1337, 100, "");
+        vm.expectRevert();
         token.safeTransferFrom(address(this), address(0), 1337, 70, "");
     }
 
-    function testFailSafeTransferFromToNonERC155Recipient() public {
+    function test_RevertWhen_SafeTransferFromToNonERC155Recipient() public {
         token.mint(address(this), 1337, 100, "");
-        token.safeTransferFrom(address(this), address(new NonERC1155Recipient()), 1337, 70, "");
+        address to = address(new NonERC1155Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), to, 1337, 70, "");
     }
 
-    function testFailSafeTransferFromToRevertingERC1155Recipient() public {
+    function test_RevertWhen_SafeTransferFromToRevertingERC1155Recipient() public {
         token.mint(address(this), 1337, 100, "");
-        token.safeTransferFrom(address(this), address(new RevertingERC1155Recipient()), 1337, 70, "");
+        address to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), to, 1337, 70, "");
     }
 
-    function testFailSafeTransferFromToWrongReturnDataERC1155Recipient() public {
+    function test_RevertWhen_SafeTransferFromToWrongReturnDataERC1155Recipient() public {
         token.mint(address(this), 1337, 100, "");
-        token.safeTransferFrom(address(this), address(new WrongReturnDataERC1155Recipient()), 1337, 70, "");
+        address to = address(new WrongReturnDataERC1155Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), to, 1337, 70, "");
     }
 
-    function testFailSafeBatchTransferInsufficientBalance() public {
+    function test_RevertWhen_SafeBatchTransferInsufficientBalance() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -566,10 +587,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeBatchTransferFrom(from, address(0xBEEF), ids, transferAmounts, "");
     }
 
-    function testFailSafeBatchTransferFromToZero() public {
+    function test_RevertWhen_SafeBatchTransferFromToZero() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -598,10 +620,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeBatchTransferFrom(from, address(0), ids, transferAmounts, "");
     }
 
-    function testFailSafeBatchTransferFromToNonERC1155Recipient() public {
+    function test_RevertWhen_SafeBatchTransferFromToNonERC1155Recipient() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -630,10 +653,12 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
-        token.safeBatchTransferFrom(from, address(new NonERC1155Recipient()), ids, transferAmounts, "");
+        address _to = address(new NonERC1155Recipient());
+        vm.expectRevert();
+        token.safeBatchTransferFrom(from, _to, ids, transferAmounts, "");
     }
 
-    function testFailSafeBatchTransferFromToRevertingERC1155Recipient() public {
+    function test_RevertWhen_SafeBatchTransferFromToRevertingERC1155Recipient() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -662,11 +687,13 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
-        token.safeBatchTransferFrom(from, address(new RevertingERC1155Recipient()), ids, transferAmounts, "");
+        address _to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
+        token.safeBatchTransferFrom(from, _to, ids, transferAmounts, "");
     }
 
 
-    function testFailSafeBatchTransferFromToWrongReturnDataERC1155Recipient() public {
+    function test_RevertWhen_SafeBatchTransferFromToWrongReturnDataERC1155Recipient() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -695,10 +722,12 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
-        token.safeBatchTransferFrom(from, address(new WrongReturnDataERC1155Recipient()), ids, transferAmounts, "");
+        address _to = address(new WrongReturnDataERC1155Recipient());
+        vm.expectRevert();
+        token.safeBatchTransferFrom(from, _to, ids, transferAmounts, "");
     }
 
-    function testFailSafeBatchTransferFromWithArrayLengthMismatch() public {
+    function test_RevertWhen_SafeBatchTransferFromWithArrayLengthMismatch() public {
         address from = address(0xABCD);
 
         uint256[] memory ids = new uint256[](5);
@@ -726,10 +755,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeBatchTransferFrom(from, address(0xBEEF), ids, transferAmounts, "");
     }
 
-    function testFailBatchMintToZero() public {
+    function test_RevertWhen_BatchMintToZero() public {
         uint256[] memory ids = new uint256[](5);
         ids[0] = 1337;
         ids[1] = 1338;
@@ -744,10 +774,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         mintAmounts[3] = 400;
         mintAmounts[4] = 500;
 
+        vm.expectRevert();
         token.batchMint(address(0), ids, mintAmounts, "");
     }
 
-    function testFailBatchMintToNonERC1155Recipient() public {
+    function test_RevertWhen_BatchMintToNonERC1155Recipient() public {
         NonERC1155Recipient to = new NonERC1155Recipient();
 
         uint256[] memory ids = new uint256[](5);
@@ -764,10 +795,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         mintAmounts[3] = 400;
         mintAmounts[4] = 500;
 
+        vm.expectRevert();
         token.batchMint(address(to), ids, mintAmounts, "");
     }
 
-    function testFailBatchMintToRevertingERC1155Recipient() public {
+    function test_RevertWhen_BatchMintToRevertingERC1155Recipient() public {
         RevertingERC1155Recipient to = new RevertingERC1155Recipient();
 
         uint256[] memory ids = new uint256[](5);
@@ -784,10 +816,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         mintAmounts[3] = 400;
         mintAmounts[4] = 500;
 
+        vm.expectRevert();
         token.batchMint(address(to), ids, mintAmounts, "");
     }
 
-    function testFailBatchMintToWrongReturnDataERC1155Recipient() public {
+    function test_RevertWhen_BatchMintToWrongReturnDataERC1155Recipient() public {
         WrongReturnDataERC1155Recipient to = new WrongReturnDataERC1155Recipient();
 
         uint256[] memory ids = new uint256[](5);
@@ -804,10 +837,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         mintAmounts[3] = 400;
         mintAmounts[4] = 500;
 
+        vm.expectRevert();
         token.batchMint(address(to), ids, mintAmounts, "");
     }
 
-    function testFailBatchMintWithArrayMismatch() public {
+    function test_RevertWhen_BatchMintWithArrayMismatch() public {
         uint256[] memory ids = new uint256[](5);
         ids[0] = 1337;
         ids[1] = 1338;
@@ -821,10 +855,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         amounts[2] = 300;
         amounts[3] = 400;
 
+        vm.expectRevert();
         token.batchMint(address(0xBEEF), ids, amounts, "");
     }
 
-    function testFailBatchBurnInsufficientBalance() public {
+    function test_RevertWhen_BatchBurnInsufficientBalance() public {
         uint256[] memory ids = new uint256[](5);
         ids[0] = 1337;
         ids[1] = 1338;
@@ -848,10 +883,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
         token.batchMint(address(0xBEEF), ids, mintAmounts, "");
 
+        vm.expectRevert();
         token.batchBurn(address(0xBEEF), ids, burnAmounts);
     }
 
-    function testFailBatchBurnWithArrayLengthMismatch() public {
+    function test_RevertWhen_BatchBurnWithArrayLengthMismatch() public {
         uint256[] memory ids = new uint256[](5);
         ids[0] = 1337;
         ids[1] = 1338;
@@ -874,10 +910,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
         token.batchMint(address(0xBEEF), ids, mintAmounts, "");
 
+        vm.expectRevert();
         token.batchBurn(address(0xBEEF), ids, burnAmounts);
     }
 
-    function testFailBalanceOfBatchWithArrayMismatch() public view {
+    function test_RevertWhen_BalanceOfBatchWithArrayMismatch() public {
         address[] memory tos = new address[](5);
         tos[0] = address(0xBEEF);
         tos[1] = address(0xCAFE);
@@ -891,6 +928,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         ids[2] = 1339;
         ids[3] = 1340;
 
+        vm.expectRevert();
         token.balanceOfBatch(tos, ids);
     }
 
@@ -1302,20 +1340,23 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         token.mint(recipient, id, mintAmount, mintData);
     }
 
-    function testFailBurnInsufficientBalance(
+    function test_RevertWhen_BurnInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
         uint256 burnAmount,
         bytes memory mintData
     ) public {
+        vm.assume(to != address(0) && to.code.length == 0);
+        vm.assume(mintAmount != type(uint256).max);
         burnAmount = bound(burnAmount, mintAmount + 1, type(uint256).max);
 
         token.mint(to, id, mintAmount, mintData);
+        vm.expectRevert();
         token.burn(to, id, burnAmount);
     }
 
-    function testFailSafeTransferFromInsufficientBalance(
+    function test_RevertWhen_SafeTransferFromInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -1325,6 +1366,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
     ) public {
         address from = address(0xABCD);
 
+        vm.assume(mintAmount != type(uint256).max);
         transferAmount = bound(transferAmount, mintAmount + 1, type(uint256).max);
 
         token.mint(from, id, mintAmount, mintData);
@@ -1332,10 +1374,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeTransferFrom(from, to, id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromSelfInsufficientBalance(
+    function test_RevertWhen_SafeTransferFromSelfInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -1343,13 +1386,15 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         bytes memory mintData,
         bytes memory transferData
     ) public {
+        vm.assume(mintAmount != type(uint256).max);
         transferAmount = bound(transferAmount, mintAmount + 1, type(uint256).max);
 
         token.mint(address(this), id, mintAmount, mintData);
+        vm.expectRevert();
         token.safeTransferFrom(address(this), to, id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToZero(
+    function test_RevertWhen_SafeTransferFromToZero(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1359,10 +1404,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         transferAmount = bound(transferAmount, 0, mintAmount);
 
         token.mint(address(this), id, mintAmount, mintData);
+        vm.expectRevert();
         token.safeTransferFrom(address(this), address(0), id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToNonERC155Recipient(
+    function test_RevertWhen_SafeTransferFromToNonERC155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1372,10 +1418,12 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         transferAmount = bound(transferAmount, 0, mintAmount);
 
         token.mint(address(this), id, mintAmount, mintData);
-        token.safeTransferFrom(address(this), address(new NonERC1155Recipient()), id, transferAmount, transferData);
+        address _to = address(new NonERC1155Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), _to, id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToRevertingERC1155Recipient(
+    function test_RevertWhen_SafeTransferFromToRevertingERC1155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1385,16 +1433,18 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         transferAmount = bound(transferAmount, 0, mintAmount);
 
         token.mint(address(this), id, mintAmount, mintData);
+        address _to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
         token.safeTransferFrom(
             address(this),
-            address(new RevertingERC1155Recipient()),
+            _to,
             id,
             transferAmount,
             transferData
         );
     }
 
-    function testFailSafeTransferFromToWrongReturnDataERC1155Recipient(
+    function test_RevertWhen_SafeTransferFromToWrongReturnDataERC1155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1404,16 +1454,18 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         transferAmount = bound(transferAmount, 0, mintAmount);
 
         token.mint(address(this), id, mintAmount, mintData);
+        address _to = address(new WrongReturnDataERC1155Recipient());
+        vm.expectRevert();
         token.safeTransferFrom(
             address(this),
-            address(new WrongReturnDataERC1155Recipient()),
+            _to,
             id,
             transferAmount,
             transferData
         );
     }
 
-    function testFailSafeBatchTransferInsufficientBalance(
+    function test_RevertWhen_SafeBatchTransferInsufficientBalance(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1425,7 +1477,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
         uint256 minLength = min3(ids.length, mintAmounts.length, transferAmounts.length);
 
-        if (minLength == 0) revert();
+        vm.assume(!(minLength == 0));
 
         uint256[] memory normalizedIds = new uint256[](minLength);
         uint256[] memory normalizedMintAmounts = new uint256[](minLength);
@@ -1437,6 +1489,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
             uint256 remainingMintAmountForId = type(uint256).max - userMintAmounts[from][id];
 
             uint256 mintAmount = bound(mintAmounts[i], 0, remainingMintAmountForId);
+            if (mintAmount == type(uint256).max) mintAmount = type(uint256).max - 1;
             uint256 transferAmount = bound(transferAmounts[i], mintAmount + 1, type(uint256).max);
 
             normalizedIds[i] = id;
@@ -1451,10 +1504,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeBatchTransferFrom(from, to, normalizedIds, normalizedTransferAmounts, transferData);
     }
 
-    function testFailSafeBatchTransferFromToZero(
+    function test_RevertWhen_SafeBatchTransferFromToZero(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1489,10 +1543,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        vm.expectRevert();
         token.safeBatchTransferFrom(from, address(0), normalizedIds, normalizedTransferAmounts, transferData);
     }
 
-    function testFailSafeBatchTransferFromToNonERC1155Recipient(
+    function test_RevertWhen_SafeBatchTransferFromToNonERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1527,16 +1582,18 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        address _to = address(new NonERC1155Recipient());
+        vm.expectRevert();
         token.safeBatchTransferFrom(
             from,
-            address(new NonERC1155Recipient()),
+            _to,
             normalizedIds,
             normalizedTransferAmounts,
             transferData
         );
     }
 
-    function testFailSafeBatchTransferFromToRevertingERC1155Recipient(
+    function test_RevertWhen_SafeBatchTransferFromToRevertingERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1571,16 +1628,18 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        address _to = address(new RevertingERC1155Recipient());
+        vm.expectRevert();
         token.safeBatchTransferFrom(
             from,
-            address(new RevertingERC1155Recipient()),
+            _to,
             normalizedIds,
             normalizedTransferAmounts,
             transferData
         );
     }
 
-    function testFailSafeBatchTransferFromToWrongReturnDataERC1155Recipient(
+    function test_RevertWhen_SafeBatchTransferFromToWrongReturnDataERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1615,16 +1674,18 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
 
+        address _to = address(new WrongReturnDataERC1155Recipient());
+        vm.expectRevert();
         token.safeBatchTransferFrom(
             from,
-            address(new WrongReturnDataERC1155Recipient()),
+            _to,
             normalizedIds,
             normalizedTransferAmounts,
             transferData
         );
     }
 
-    function testFailSafeBatchTransferFromWithArrayLengthMismatch(
+    function test_RevertWhen_SafeBatchTransferFromWithArrayLengthMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1632,10 +1693,23 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         bytes memory mintData,
         bytes memory transferData
     ) public {
+        vm.assume(!(ids.length == transferAmounts.length));
+
+        // The whole body must revert: either the setup batchMint (mismatched
+        // ids/mintAmounts, etc.) or the safeBatchTransferFrom array-length mismatch.
+        vm.expectRevert();
+        this.batchMintThenBatchTransfer(to, ids, mintAmounts, transferAmounts, mintData, transferData);
+    }
+
+    function batchMintThenBatchTransfer(
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata mintAmounts,
+        uint256[] calldata transferAmounts,
+        bytes calldata mintData,
+        bytes calldata transferData
+    ) external {
         address from = address(0xABCD);
-
-        if (ids.length == transferAmounts.length) revert();
-
         token.batchMint(from, ids, mintAmounts, mintData);
 
         vm.prank(from);
@@ -1644,7 +1718,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
         token.safeBatchTransferFrom(from, to, ids, transferAmounts, transferData);
     }
 
-    function testFailBatchMintToZero(
+    function test_RevertWhen_BatchMintToZero(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1667,10 +1741,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
             userMintAmounts[address(0)][id] += mintAmount;
         }
 
+        vm.expectRevert();
         token.batchMint(address(0), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToNonERC1155Recipient(
+    function test_RevertWhen_BatchMintToNonERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1695,10 +1770,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
             userMintAmounts[address(to)][id] += mintAmount;
         }
 
+        vm.expectRevert();
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToRevertingERC1155Recipient(
+    function test_RevertWhen_BatchMintToRevertingERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1723,10 +1799,11 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
             userMintAmounts[address(to)][id] += mintAmount;
         }
 
+        vm.expectRevert();
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToWrongReturnDataERC1155Recipient(
+    function test_RevertWhen_BatchMintToWrongReturnDataERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1751,21 +1828,23 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
             userMintAmounts[address(to)][id] += mintAmount;
         }
 
+        vm.expectRevert();
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintWithArrayMismatch(
+    function test_RevertWhen_BatchMintWithArrayMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
     ) public {
-        if (ids.length == amounts.length) revert();
+        vm.assume(!(ids.length == amounts.length));
 
+        vm.expectRevert();
         token.batchMint(address(to), ids, amounts, mintData);
     }
 
-    function testFailBatchBurnInsufficientBalance(
+    function test_RevertWhen_BatchBurnInsufficientBalance(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1774,7 +1853,10 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
     ) public {
         uint256 minLength = min3(ids.length, mintAmounts.length, burnAmounts.length);
 
-        if (minLength == 0) revert();
+        vm.assume(!(minLength == 0));
+        // `to` must be a valid recipient so the setup batchMint succeeds; the
+        // asserted revert comes from the subsequent insufficient-balance batchBurn.
+        vm.assume(to != address(0) && to.code.length == 0);
 
         uint256[] memory normalizedIds = new uint256[](minLength);
         uint256[] memory normalizedMintAmounts = new uint256[](minLength);
@@ -1787,6 +1869,7 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
             normalizedIds[i] = id;
             normalizedMintAmounts[i] = bound(mintAmounts[i], 0, remainingMintAmountForId);
+            if (normalizedMintAmounts[i] == type(uint256).max) normalizedMintAmounts[i] = type(uint256).max - 1;
             normalizedBurnAmounts[i] = bound(burnAmounts[i], normalizedMintAmounts[i] + 1, type(uint256).max);
 
             userMintAmounts[to][id] += normalizedMintAmounts[i];
@@ -1794,26 +1877,41 @@ contract ERC1155Test is Test, ERC1155Recipient, FuzzingUtils {
 
         token.batchMint(to, normalizedIds, normalizedMintAmounts, mintData);
 
+        vm.expectRevert();
         token.batchBurn(to, normalizedIds, normalizedBurnAmounts);
     }
 
-    function testFailBatchBurnWithArrayLengthMismatch(
+    function test_RevertWhen_BatchBurnWithArrayLengthMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory burnAmounts,
         bytes memory mintData
     ) public {
-        if (ids.length == burnAmounts.length) revert();
+        vm.assume(!(ids.length == burnAmounts.length));
 
+        // The whole body must revert: either the setup batchMint (e.g. mismatched
+        // ids/mintAmounts, bad recipient) or the batchBurn array-length mismatch.
+        // Route it through an external call so vm.expectRevert catches whichever fires.
+        vm.expectRevert();
+        this.batchMintThenBurn(to, ids, mintAmounts, burnAmounts, mintData);
+    }
+
+    function batchMintThenBurn(
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata mintAmounts,
+        uint256[] calldata burnAmounts,
+        bytes calldata mintData
+    ) external {
         token.batchMint(to, ids, mintAmounts, mintData);
-
         token.batchBurn(to, ids, burnAmounts);
     }
 
-    function testFailBalanceOfBatchWithArrayMismatch(address[] memory tos, uint256[] memory ids) public view {
-        if (tos.length == ids.length) revert();
+    function test_RevertWhen_BalanceOfBatchWithArrayMismatch(address[] memory tos, uint256[] memory ids) public {
+        vm.assume(!(tos.length == ids.length));
 
+        vm.expectRevert();
         token.balanceOfBatch(tos, ids);
     }
 }

--- a/test/tokens/ERC20.t.sol
+++ b/test/tokens/ERC20.t.sol
@@ -220,12 +220,13 @@ contract ERC20Test is Test {
         assertEq(token.balanceOf(address(0xBEEF)), 1e18);
     }
 
-    function testFailTransferInsufficientBalance() public {
+    function test_RevertWhen_TransferInsufficientBalance() public {
         token.mint(address(this), 0.9e18);
+        vm.expectRevert();
         token.transfer(address(0xBEEF), 1e18);
     }
 
-    function testFailTransferFromInsufficientAllowance() public {
+    function test_RevertWhen_TransferFromInsufficientAllowance() public {
         address from = address(0xABCD);
 
         token.mint(from, 1e18);
@@ -234,10 +235,11 @@ contract ERC20Test is Test {
         token.approve(address(this), 0.9e18);
         vm.stopPrank();
 
+        vm.expectRevert();
         token.transferFrom(from, address(0xBEEF), 1e18);
     }
 
-    function testFailTransferFromInsufficientBalance() public {
+    function test_RevertWhen_TransferFromInsufficientBalance() public {
         address from = address(0xABCD);
 
         token.mint(from, 0.9e18);
@@ -246,6 +248,7 @@ contract ERC20Test is Test {
         token.approve(address(this), 1e18);
         vm.stopPrank();
 
+        vm.expectRevert();
         token.transferFrom(from, address(0xBEEF), 1e18);
     }
 
@@ -321,33 +324,39 @@ contract ERC20Test is Test {
         }
     }
 
-    function testFailBurnInsufficientBalance(
+    function test_RevertWhen_BurnInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 burnAmount
     ) public {
+        vm.assume(to != address(0));
+        vm.assume(mintAmount != type(uint256).max);
         burnAmount = bound(burnAmount, mintAmount + 1, type(uint256).max);
 
         token.mint(to, mintAmount);
+        vm.expectRevert();
         token.burn(to, burnAmount);
     }
 
-    function testFailTransferInsufficientBalance(
+    function test_RevertWhen_TransferInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 sendAmount
     ) public {
+        vm.assume(mintAmount != type(uint256).max);
         sendAmount = bound(sendAmount, mintAmount + 1, type(uint256).max);
 
         token.mint(address(this), mintAmount);
+        vm.expectRevert();
         token.transfer(to, sendAmount);
     }
 
-    function testFailTransferFromInsufficientAllowance(
+    function test_RevertWhen_TransferFromInsufficientAllowance(
         address to,
         uint256 approval,
         uint256 amount
     ) public {
+        vm.assume(approval != type(uint256).max);
         amount = bound(amount, approval + 1, type(uint256).max);
 
         address from = address(0xABCD);
@@ -358,14 +367,16 @@ contract ERC20Test is Test {
         token.approve(address(this), approval);
         vm.stopPrank();
 
+        vm.expectRevert();
         token.transferFrom(from, to, amount);
     }
 
-    function testFailTransferFromInsufficientBalance(
+    function test_RevertWhen_TransferFromInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 sendAmount
     ) public {
+        vm.assume(mintAmount != type(uint256).max);
         sendAmount = bound(sendAmount, mintAmount + 1, type(uint256).max);
 
         address from = address(0xABCD);
@@ -376,6 +387,7 @@ contract ERC20Test is Test {
         token.approve(address(this), sendAmount);
         vm.stopPrank();
 
+        vm.expectRevert();
         token.transferFrom(from, to, sendAmount);
     }
 
@@ -425,7 +437,7 @@ contract ERC20Test is Test {
         assertEq(token.nonces(owner), 1);
     }
 
-    function testFailPermitBadNonce() public {
+    function test_RevertWhen_PermitBadNonce() public {
         uint256 privateKey = 0xBEEF;
         address owner = vm.addr(privateKey);
 
@@ -449,10 +461,11 @@ contract ERC20Test is Test {
             )
         );
 
+        vm.expectRevert();
         token.permit(owner, address(0xCAFE), 1e18, block.timestamp, v, r, s);
     }
 
-    function testFailPermitBadDeadline() public {
+    function test_RevertWhen_PermitBadDeadline() public {
         uint256 privateKey = 0xBEEF;
         address owner = vm.addr(privateKey);
 
@@ -476,6 +489,7 @@ contract ERC20Test is Test {
             )
         );
 
+        vm.expectRevert();
         token.permit(
             owner,
             address(0xCAFE),
@@ -523,7 +537,7 @@ contract ERC20Test is Test {
         );
     }
 
-    function testFailPermitReplay() public {
+    function test_RevertWhen_PermitReplay() public {
         uint256 privateKey = 0xBEEF;
         address owner = vm.addr(privateKey);
 
@@ -548,6 +562,7 @@ contract ERC20Test is Test {
         );
 
         token.permit(owner, address(0xCAFE), 1e18, block.timestamp, v, r, s);
+        vm.expectRevert();
         token.permit(owner, address(0xCAFE), 1e18, block.timestamp, v, r, s);
     }
 

--- a/test/tokens/ERC4626.t.sol
+++ b/test/tokens/ERC4626.t.sol
@@ -389,49 +389,57 @@ contract ERC4626Test is Test {
         assertEq(underlying.balanceOf(address(vault)), 0);
     }
 
-    function testFailDepositWithNotEnoughApproval() public {
+    function test_RevertWhen_DepositWithNotEnoughApproval() public {
         underlying.mint(address(this), 0.5e18);
         underlying.approve(address(vault), 0.5e18);
         assertEq(underlying.allowance(address(this), address(vault)), 0.5e18);
 
+        vm.expectRevert();
         vault.deposit(1e18, address(this));
     }
 
-    function testFailWithdrawWithNotEnoughUnderlyingAmount() public {
+    function test_RevertWhen_WithdrawWithNotEnoughUnderlyingAmount() public {
         underlying.mint(address(this), 0.5e18);
         underlying.approve(address(vault), 0.5e18);
 
         vault.deposit(0.5e18, address(this));
 
+        vm.expectRevert();
         vault.withdraw(1e18, address(this), address(this));
     }
 
-    function testFailRedeemWithNotEnoughShareAmount() public {
+    function test_RevertWhen_RedeemWithNotEnoughShareAmount() public {
         underlying.mint(address(this), 0.5e18);
         underlying.approve(address(vault), 0.5e18);
 
         vault.deposit(0.5e18, address(this));
 
+        vm.expectRevert();
         vault.redeem(1e18, address(this), address(this));
     }
 
-    function testFailWithdrawWithNoUnderlyingAmount() public {
+    function test_RevertWhen_WithdrawWithNoUnderlyingAmount() public {
+        vm.expectRevert();
         vault.withdraw(1e18, address(this), address(this));
     }
 
-    function testFailRedeemWithNoShareAmount() public {
+    function test_RevertWhen_RedeemWithNoShareAmount() public {
+        vm.expectRevert();
         vault.redeem(1e18, address(this), address(this));
     }
 
-    function testFailDepositWithNoApproval() public {
+    function test_RevertWhen_DepositWithNoApproval() public {
+        vm.expectRevert();
         vault.deposit(1e18, address(this));
     }
 
-    function testFailMintWithNoApproval() public {
+    function test_RevertWhen_MintWithNoApproval() public {
+        vm.expectRevert();
         vault.mint(1e18, address(this));
     }
 
-    function testFailDepositZero() public {
+    function test_RevertWhen_DepositZero() public {
+        vm.expectRevert();
         vault.deposit(0, address(this));
     }
 
@@ -444,7 +452,8 @@ contract ERC4626Test is Test {
         assertEq(vault.totalAssets(), 0);
     }
 
-    function testFailRedeemZero() public {
+    function test_RevertWhen_RedeemZero() public {
+        vm.expectRevert();
         vault.redeem(0, address(this), address(this));
     }
 

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -351,116 +351,150 @@ contract ERC721Test is Test {
         assertEq(keccak256(abi.encode(to.data())), keccak256(abi.encode("testing 123")));
     }
 
-    function testFailMintToZero() public {
+    function test_RevertWhen_MintToZero() public {
+        vm.expectRevert();
         token.mint(address(0), 1337);
     }
 
-    function testFailDoubleMint() public {
+    function test_RevertWhen_DoubleMint() public {
         token.mint(address(0xBEEF), 1337);
+        vm.expectRevert();
         token.mint(address(0xBEEF), 1337);
     }
 
-    function testFailBurnUnMinted() public {
+    function test_RevertWhen_BurnUnMinted() public {
+        vm.expectRevert();
         token.burn(1337);
     }
 
-    function testFailDoubleBurn() public {
+    function test_RevertWhen_DoubleBurn() public {
         token.mint(address(0xBEEF), 1337);
 
         token.burn(1337);
+        vm.expectRevert();
         token.burn(1337);
     }
 
-    function testFailApproveUnMinted() public {
+    function test_RevertWhen_ApproveUnMinted() public {
+        vm.expectRevert();
         token.approve(address(0xBEEF), 1337);
     }
 
-    function testFailApproveUnAuthorized() public {
+    function test_RevertWhen_ApproveUnAuthorized() public {
         token.mint(address(0xCAFE), 1337);
 
+        vm.expectRevert();
         token.approve(address(0xBEEF), 1337);
     }
 
-    function testFailTransferFromUnOwned() public {
+    function test_RevertWhen_TransferFromUnOwned() public {
+        vm.expectRevert();
         token.transferFrom(address(0xFEED), address(0xBEEF), 1337);
     }
 
-    function testFailTransferFromWrongFrom() public {
+    function test_RevertWhen_TransferFromWrongFrom() public {
         token.mint(address(0xCAFE), 1337);
 
+        vm.expectRevert();
         token.transferFrom(address(0xFEED), address(0xBEEF), 1337);
     }
 
-    function testFailTransferFromToZero() public {
+    function test_RevertWhen_TransferFromToZero() public {
         token.mint(address(this), 1337);
 
+        vm.expectRevert();
         token.transferFrom(address(this), address(0), 1337);
     }
 
-    function testFailTransferFromNotOwner() public {
+    function test_RevertWhen_TransferFromNotOwner() public {
         token.mint(address(0xFEED), 1337);
 
+        vm.expectRevert();
         token.transferFrom(address(0xFEED), address(0xBEEF), 1337);
     }
 
-    function testFailSafeTransferFromToNonERC721Recipient() public {
+    function test_RevertWhen_SafeTransferFromToNonERC721Recipient() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new NonERC721Recipient()), 1337);
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337);
     }
 
-    function testFailSafeTransferFromToNonERC721RecipientWithData() public {
+    function test_RevertWhen_SafeTransferFromToNonERC721RecipientWithData() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new NonERC721Recipient()), 1337, "testing 123");
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337, "testing 123");
     }
 
-    function testFailSafeTransferFromToRevertingERC721Recipient() public {
+    function test_RevertWhen_SafeTransferFromToRevertingERC721Recipient() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), 1337);
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337);
     }
 
-    function testFailSafeTransferFromToRevertingERC721RecipientWithData() public {
+    function test_RevertWhen_SafeTransferFromToRevertingERC721RecipientWithData() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), 1337, "testing 123");
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337, "testing 123");
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnData() public {
+    function test_RevertWhen_SafeTransferFromToERC721RecipientWithWrongReturnData() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), 1337);
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337);
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnDataWithData() public {
+    function test_RevertWhen_SafeTransferFromToERC721RecipientWithWrongReturnDataWithData() public {
         token.mint(address(this), 1337);
 
-        token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), 1337, "testing 123");
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, 1337, "testing 123");
     }
 
-    function testFailSafeMintToNonERC721Recipient() public {
-        token.safeMint(address(new NonERC721Recipient()), 1337);
+    function test_RevertWhen_SafeMintToNonERC721Recipient() public {
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337);
     }
 
-    function testFailSafeMintToNonERC721RecipientWithData() public {
-        token.safeMint(address(new NonERC721Recipient()), 1337, "testing 123");
+    function test_RevertWhen_SafeMintToNonERC721RecipientWithData() public {
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337, "testing 123");
     }
 
-    function testFailSafeMintToRevertingERC721Recipient() public {
-        token.safeMint(address(new RevertingERC721Recipient()), 1337);
+    function test_RevertWhen_SafeMintToRevertingERC721Recipient() public {
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337);
     }
 
-    function testFailSafeMintToRevertingERC721RecipientWithData() public {
-        token.safeMint(address(new RevertingERC721Recipient()), 1337, "testing 123");
+    function test_RevertWhen_SafeMintToRevertingERC721RecipientWithData() public {
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337, "testing 123");
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnData() public {
-        token.safeMint(address(new WrongReturnDataERC721Recipient()), 1337);
+    function test_RevertWhen_SafeMintToERC721RecipientWithWrongReturnData() public {
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337);
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnDataWithData() public {
-        token.safeMint(address(new WrongReturnDataERC721Recipient()), 1337, "testing 123");
+    function test_RevertWhen_SafeMintToERC721RecipientWithWrongReturnDataWithData() public {
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, 1337, "testing 123");
     }
 
     function testBalanceOfZeroAddress() public {
@@ -677,35 +711,40 @@ contract ERC721Test is Test {
         assertEq(keccak256(abi.encode(to.data())), keccak256(abi.encode(data)));
     }
 
-    function testFailMintToZero(uint256 id) public {
+    function test_RevertWhen_MintToZero(uint256 id) public {
+        vm.expectRevert();
         token.mint(address(0), id);
     }
 
-    function testFailDoubleMint(uint256 id, address to) public {
+    function test_RevertWhen_DoubleMint(uint256 id, address to) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
+        vm.expectRevert();
         token.mint(to, id);
     }
 
-    function testFailBurnUnMinted(uint256 id) public {
+    function test_RevertWhen_BurnUnMinted(uint256 id) public {
+        vm.expectRevert();
         token.burn(id);
     }
 
-    function testFailDoubleBurn(uint256 id, address to) public {
+    function test_RevertWhen_DoubleBurn(uint256 id, address to) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
 
         token.burn(id);
+        vm.expectRevert();
         token.burn(id);
     }
 
-    function testFailApproveUnMinted(uint256 id, address to) public {
+    function test_RevertWhen_ApproveUnMinted(uint256 id, address to) public {
+        vm.expectRevert();
         token.approve(to, id);
     }
 
-    function testFailApproveUnAuthorized(
+    function test_RevertWhen_ApproveUnAuthorized(
         address owner,
         uint256 id,
         address to
@@ -714,109 +753,139 @@ contract ERC721Test is Test {
 
         token.mint(owner, id);
 
+        vm.expectRevert();
         token.approve(to, id);
     }
 
-    function testFailTransferFromUnOwned(
+    function test_RevertWhen_TransferFromUnOwned(
         address from,
         address to,
         uint256 id
     ) public {
+        vm.expectRevert();
         token.transferFrom(from, to, id);
     }
 
-    function testFailTransferFromWrongFrom(
+    function test_RevertWhen_TransferFromWrongFrom(
         address owner,
         address from,
         address to,
         uint256 id
     ) public {
-        if (owner == address(0)) to = address(0xBEEF);
-        if (from == owner) revert();
+        vm.assume(owner != address(0));
+        vm.assume(from != owner);
 
         token.mint(owner, id);
 
+        vm.expectRevert();
         token.transferFrom(from, to, id);
     }
 
-    function testFailTransferFromToZero(uint256 id) public {
+    function test_RevertWhen_TransferFromToZero(uint256 id) public {
         token.mint(address(this), id);
 
+        vm.expectRevert();
         token.transferFrom(address(this), address(0), id);
     }
 
-    function testFailTransferFromNotOwner(
+    function test_RevertWhen_TransferFromNotOwner(
         address from,
         address to,
         uint256 id
     ) public {
         if (from == address(this)) from = address(0xBEEF);
+        vm.assume(from != address(0));
 
         token.mint(from, id);
 
+        vm.expectRevert();
         token.transferFrom(from, to, id);
     }
 
-    function testFailSafeTransferFromToNonERC721Recipient(uint256 id) public {
+    function test_RevertWhen_SafeTransferFromToNonERC721Recipient(uint256 id) public {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new NonERC721Recipient()), id);
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id);
     }
 
-    function testFailSafeTransferFromToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function test_RevertWhen_SafeTransferFromToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new NonERC721Recipient()), id, data);
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id, data);
     }
 
-    function testFailSafeTransferFromToRevertingERC721Recipient(uint256 id) public {
+    function test_RevertWhen_SafeTransferFromToRevertingERC721Recipient(uint256 id) public {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), id);
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id);
     }
 
-    function testFailSafeTransferFromToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function test_RevertWhen_SafeTransferFromToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), id, data);
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id, data);
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnData(uint256 id) public {
+    function test_RevertWhen_SafeTransferFromToERC721RecipientWithWrongReturnData(uint256 id) public {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), id);
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id);
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data)
+    function test_RevertWhen_SafeTransferFromToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data)
         public
     {
         token.mint(address(this), id);
 
-        token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), id, data);
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeTransferFrom(address(this), recipient, id, data);
     }
 
-    function testFailSafeMintToNonERC721Recipient(uint256 id) public {
-        token.safeMint(address(new NonERC721Recipient()), id);
+    function test_RevertWhen_SafeMintToNonERC721Recipient(uint256 id) public {
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id);
     }
 
-    function testFailSafeMintToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
-        token.safeMint(address(new NonERC721Recipient()), id, data);
+    function test_RevertWhen_SafeMintToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
+        address recipient = address(new NonERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id, data);
     }
 
-    function testFailSafeMintToRevertingERC721Recipient(uint256 id) public {
-        token.safeMint(address(new RevertingERC721Recipient()), id);
+    function test_RevertWhen_SafeMintToRevertingERC721Recipient(uint256 id) public {
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id);
     }
 
-    function testFailSafeMintToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
-        token.safeMint(address(new RevertingERC721Recipient()), id, data);
+    function test_RevertWhen_SafeMintToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
+        address recipient = address(new RevertingERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id, data);
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnData(uint256 id) public {
-        token.safeMint(address(new WrongReturnDataERC721Recipient()), id);
+    function test_RevertWhen_SafeMintToERC721RecipientWithWrongReturnData(uint256 id) public {
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id);
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data) public {
-        token.safeMint(address(new WrongReturnDataERC721Recipient()), id, data);
+    function test_RevertWhen_SafeMintToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data) public {
+        address recipient = address(new WrongReturnDataERC721Recipient());
+        vm.expectRevert();
+        token.safeMint(recipient, id, data);
     }
 
     function testOwnerOfUnminted(uint256 id) public {

--- a/test/utils/CREATE3.t.sol
+++ b/test/utils/CREATE3.t.sol
@@ -41,17 +41,19 @@ contract CREATE3Test is Test {
         assertEq(deployed.decimals(), 18);
     }
 
-    function testFailDoubleDeploySameBytecode() public {
+    function test_RevertWhen_DoubleDeploySameBytecode() public {
         bytes32 salt = keccak256(bytes("Salty..."));
 
         create3.deploy(salt, type(MockAuthChild).creationCode, 0);
+        vm.expectRevert();
         create3.deploy(salt, type(MockAuthChild).creationCode, 0);
     }
 
-    function testFailDoubleDeployDifferentBytecode() public {
+    function test_RevertWhen_DoubleDeployDifferentBytecode() public {
         bytes32 salt = keccak256(bytes("and sweet!"));
 
         create3.deploy(salt, type(WETH).creationCode, 0);
+        vm.expectRevert();
         create3.deploy(salt, type(MockAuthChild).creationCode, 0);
     }
 
@@ -72,16 +74,24 @@ contract CREATE3Test is Test {
         assertEq(deployed.decimals(), decimals);
     }
 
-    function testFailDoubleDeploySameBytecode(bytes32 salt, bytes calldata bytecode) public {
-        create3.deploy(salt, bytecode, 0);
-        create3.deploy(salt, bytecode, 0);
+    function test_RevertWhen_DoubleDeploySameBytecode(bytes32 salt, bytes calldata bytecode) public {
+        vm.expectRevert();
+        this.doubleDeploy(salt, bytecode, bytecode);
     }
 
-    function testFailDoubleDeployDifferentBytecode(
+    function test_RevertWhen_DoubleDeployDifferentBytecode(
         bytes32 salt,
         bytes calldata bytecode1,
         bytes calldata bytecode2
     ) public {
+        vm.expectRevert();
+        this.doubleDeploy(salt, bytecode1, bytecode2);
+    }
+
+    /// @dev External helper so `vm.expectRevert` can capture a revert from
+    ///      either deploy (the first may revert on garbage bytecode, the
+    ///      second always reverts on the salt collision).
+    function doubleDeploy(bytes32 salt, bytes calldata bytecode1, bytes calldata bytecode2) public {
         create3.deploy(salt, bytecode1, 0);
         create3.deploy(salt, bytecode2, 0);
     }

--- a/test/utils/JumpTableUtil.t.sol
+++ b/test/utils/JumpTableUtil.t.sol
@@ -12,7 +12,7 @@ interface IJumpTableUtil {
 }
 
 contract JumpTableUtilTest is Test {
-    uint constant FIRST_LABEL_PC = 147;
+    uint constant FIRST_LABEL_PC = 141;
 
     IJumpTableUtil jtUtil;
 

--- a/test/utils/SSTORE2.t.sol
+++ b/test/utils/SSTORE2.t.sol
@@ -105,13 +105,13 @@ contract SSTORE2Test is Test {
 
     /// @notice End can never be less than start
     function testReadBetweenOutOfBounds(uint256 start, uint256 end, bytes memory input) public {
-        // Make sure the end is always less than the start
-        if (end > start) (start, end) = (end, start);
-        vm.assume(end != type(uint256).max);
-        if (end == start) start = end + 1;
+        // Need at least one byte so there is a valid [end, start) range with end < start.
+        vm.assume(input.length > 0);
 
-        // Make sure the start is never greater than the codesize (the length of input)
-        vm.assume(start <= input.length);
+        // Bound (rather than assume) into range so the fuzzer isn't starved:
+        // start in [1, input.length], end strictly less than start.
+        start = bound(start, 1, input.length);
+        end = bound(end, 0, start - 1);
 
         // Write the input
         address pointer = store.write(input);

--- a/test/utils/SafeTransferLib.t.sol
+++ b/test/utils/SafeTransferLib.t.sol
@@ -353,10 +353,10 @@ contract SafeTransferLibTest is Test {
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
         // Transferring to msg.sender can fail because it's possible to overflow their ETH balance as it begins non-zero.
-        vm.assume(recipient > address(9) && recipient.code.length == 0 && recipient != msg.sender);
+        // >0xffff excludes precompiles (incl. the EIP-2537 BLS precompiles at 0x0a-0x11).
+        vm.assume(recipient > address(0xffff) && recipient.code.length == 0 && recipient != msg.sender);
         vm.assume(recipient != VM_ADDRESS && recipient != CONSOLE);
-        // Exclude precompiles (e.g. the EIP-2537 BLS precompiles at 0x0a-0x11) and any
-        // other address that rejects a plain ETH transfer.
+        // Also exclude any other address that rejects a plain ETH transfer.
         assumePayable(recipient);
 
         amount = bound(amount, 0, address(SafeTransferLib).balance);

--- a/test/utils/SafeTransferLib.t.sol
+++ b/test/utils/SafeTransferLib.t.sol
@@ -127,58 +127,67 @@ contract SafeTransferLibTest is Test {
 
     function testTransferRevertSelector() public {
         vm.expectRevert(TransferFailed.selector);
-        this.testFailTransferWithReturnsFalse();
+        this.verifySafeTransfer(address(returnsFalse), address(0xBEEF), 1e18);
     }
 
     function testTransferFromRevertSelector() public {
         vm.expectRevert(TransferFromFailed.selector);
-        this.testFailTransferFromWithReturnsFalse();
+        this.verifySafeTransferFrom(address(returnsFalse), address(0xFEED), address(0xBEEF), 1e18);
     }
 
     function testApproveRevertSelector() public {
         vm.expectRevert(ApproveFailed.selector);
-        this.testFailApproveWithReturnsFalse();
+        this.verifySafeApprove(address(returnsFalse), address(0xBEEF), 1e18);
     }
 
     function testTransferETHRevertSelector() public {
         vm.expectRevert(ETHTransferFailed.selector);
-        this.testFailTransferETHToContractWithoutFallback();
+        SafeTransferLib.safeTransferETH(address(this), 1e18);
     }
 
-    function testFailTransferWithReturnsFalse() public {
-        verifySafeTransfer(address(returnsFalse), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferWithReturnsFalse() public {
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsFalse), address(0xBEEF), 1e18);
     }
 
-    function testFailTransferWithReverting() public {
-        verifySafeTransfer(address(reverting), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferWithReverting() public {
+        vm.expectRevert();
+        this.verifySafeTransfer(address(reverting), address(0xBEEF), 1e18);
     }
 
-    function testFailTransferWithReturnsTooLittle() public {
-        verifySafeTransfer(address(returnsTooLittle), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferWithReturnsTooLittle() public {
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsTooLittle), address(0xBEEF), 1e18);
     }
 
-    function testFailTransferFromWithReturnsFalse() public {
-        verifySafeTransferFrom(address(returnsFalse), address(0xFEED), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferFromWithReturnsFalse() public {
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsFalse), address(0xFEED), address(0xBEEF), 1e18);
     }
 
-    function testFailTransferFromWithReverting() public {
-        verifySafeTransferFrom(address(reverting), address(0xFEED), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferFromWithReverting() public {
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(reverting), address(0xFEED), address(0xBEEF), 1e18);
     }
 
-    function testFailTransferFromWithReturnsTooLittle() public {
-        verifySafeTransferFrom(address(returnsTooLittle), address(0xFEED), address(0xBEEF), 1e18);
+    function test_RevertWhen_TransferFromWithReturnsTooLittle() public {
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsTooLittle), address(0xFEED), address(0xBEEF), 1e18);
     }
 
-    function testFailApproveWithReturnsFalse() public {
-        verifySafeApprove(address(returnsFalse), address(0xBEEF), 1e18);
+    function test_RevertWhen_ApproveWithReturnsFalse() public {
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsFalse), address(0xBEEF), 1e18);
     }
 
-    function testFailApproveWithReverting() public {
-        verifySafeApprove(address(reverting), address(0xBEEF), 1e18);
+    function test_RevertWhen_ApproveWithReverting() public {
+        vm.expectRevert();
+        this.verifySafeApprove(address(reverting), address(0xBEEF), 1e18);
     }
 
-    function testFailApproveWithReturnsTooLittle() public {
-        verifySafeApprove(address(returnsTooLittle), address(0xBEEF), 1e18);
+    function test_RevertWhen_ApproveWithReturnsTooLittle() public {
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsTooLittle), address(0xBEEF), 1e18);
     }
 
     function testFuzzTransferWithMissingReturn(
@@ -224,13 +233,14 @@ contract SafeTransferLibTest is Test {
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        vm.assume(nonContract > address(9) && nonContract.code.length == 0);
+        vm.assume(nonContract > address(0xffff) && nonContract.code.length == 0); // >0xffff excludes precompiles (incl. EIP-2537 BLS at 0x0a-0x11)
         vm.assume(nonContract != VM_ADDRESS && nonContract != CONSOLE);
 
         SafeTransferLib.safeTransfer(nonContract, to, amount);
     }
 
-    function testFailTransferETHToContractWithoutFallback() public {
+    function test_RevertWhen_TransferETHToContractWithoutFallback() public {
+        vm.expectRevert();
         SafeTransferLib.safeTransferETH(address(this), 1e18);
     }
 
@@ -282,7 +292,7 @@ contract SafeTransferLibTest is Test {
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        vm.assume(nonContract > address(9) && nonContract.code.length == 0);
+        vm.assume(nonContract > address(0xffff) && nonContract.code.length == 0); // >0xffff excludes precompiles (incl. EIP-2537 BLS at 0x0a-0x11)
         vm.assume(nonContract != VM_ADDRESS && nonContract != CONSOLE);
 
         SafeTransferLib.safeTransferFrom(nonContract, from, to, amount);
@@ -331,7 +341,7 @@ contract SafeTransferLibTest is Test {
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        vm.assume(nonContract > address(9) && nonContract.code.length == 0);
+        vm.assume(nonContract > address(0xffff) && nonContract.code.length == 0); // >0xffff excludes precompiles (incl. EIP-2537 BLS at 0x0a-0x11)
         vm.assume(nonContract != VM_ADDRESS && nonContract != CONSOLE);
 
         SafeTransferLib.safeApprove(nonContract, to, amount);
@@ -345,156 +355,175 @@ contract SafeTransferLibTest is Test {
         // Transferring to msg.sender can fail because it's possible to overflow their ETH balance as it begins non-zero.
         vm.assume(recipient > address(9) && recipient.code.length == 0 && recipient != msg.sender);
         vm.assume(recipient != VM_ADDRESS && recipient != CONSOLE);
+        // Exclude precompiles (e.g. the EIP-2537 BLS precompiles at 0x0a-0x11) and any
+        // other address that rejects a plain ETH transfer.
+        assumePayable(recipient);
 
         amount = bound(amount, 0, address(SafeTransferLib).balance);
 
         SafeTransferLib.safeTransferETH(recipient, amount);
     }
 
-    function testFailFuzzTransferWithReturnsFalse(
+    function test_RevertWhen_FuzzTransferWithReturnsFalse(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransfer(address(returnsFalse), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsFalse), to, amount);
     }
 
-    function testFailFuzzTransferWithReverting(
+    function test_RevertWhen_FuzzTransferWithReverting(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransfer(address(reverting), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransfer(address(reverting), to, amount);
     }
 
-    function testFailFuzzTransferWithReturnsTooLittle(
+    function test_RevertWhen_FuzzTransferWithReturnsTooLittle(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransfer(address(returnsTooLittle), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsTooLittle), to, amount);
     }
 
-    function testFailFuzzTransferWithReturnsTwo(
+    function test_RevertWhen_FuzzTransferWithReturnsTwo(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransfer(address(returnsTwo), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsTwo), to, amount);
     }
 
-    function testFailFuzzTransferWithGarbage(
-        address to,
-        uint256 amount,
-        bytes memory garbage,
-        bytes calldata brutalizeWith
-    ) public brutalizeMemory(brutalizeWith) {
-        require(garbageIsGarbage(garbage));
-
-        returnsGarbage.setGarbage(garbage);
-
-        verifySafeTransfer(address(returnsGarbage), to, amount);
-    }
-
-    function testFailFuzzTransferFromWithReturnsFalse(
-        address from,
-        address to,
-        uint256 amount,
-        bytes calldata brutalizeWith
-    ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransferFrom(address(returnsFalse), from, to, amount);
-    }
-
-    function testFailFuzzTransferFromWithReverting(
-        address from,
-        address to,
-        uint256 amount,
-        bytes calldata brutalizeWith
-    ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransferFrom(address(reverting), from, to, amount);
-    }
-
-    function testFailFuzzTransferFromWithReturnsTooLittle(
-        address from,
-        address to,
-        uint256 amount,
-        bytes calldata brutalizeWith
-    ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransferFrom(address(returnsTooLittle), from, to, amount);
-    }
-
-    function testFailFuzzTransferFromWithReturnsTwo(
-        address from,
-        address to,
-        uint256 amount,
-        bytes calldata brutalizeWith
-    ) public brutalizeMemory(brutalizeWith) {
-        verifySafeTransferFrom(address(returnsTwo), from, to, amount);
-    }
-
-    function testFailFuzzTransferFromWithGarbage(
-        address from,
+    function test_RevertWhen_FuzzTransferWithGarbage(
         address to,
         uint256 amount,
         bytes memory garbage,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        require(garbageIsGarbage(garbage));
+        vm.assume(garbageIsGarbage(garbage));
 
         returnsGarbage.setGarbage(garbage);
 
-        verifySafeTransferFrom(address(returnsGarbage), from, to, amount);
+        vm.expectRevert();
+        this.verifySafeTransfer(address(returnsGarbage), to, amount);
     }
 
-    function testFailFuzzApproveWithReturnsFalse(
+    function test_RevertWhen_FuzzTransferFromWithReturnsFalse(
+        address from,
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeApprove(address(returnsFalse), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsFalse), from, to, amount);
     }
 
-    function testFailFuzzApproveWithReverting(
+    function test_RevertWhen_FuzzTransferFromWithReverting(
+        address from,
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeApprove(address(reverting), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(reverting), from, to, amount);
     }
 
-    function testFailFuzzApproveWithReturnsTooLittle(
+    function test_RevertWhen_FuzzTransferFromWithReturnsTooLittle(
+        address from,
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeApprove(address(returnsTooLittle), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsTooLittle), from, to, amount);
     }
 
-    function testFailFuzzApproveWithReturnsTwo(
+    function test_RevertWhen_FuzzTransferFromWithReturnsTwo(
+        address from,
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        verifySafeApprove(address(returnsTwo), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsTwo), from, to, amount);
     }
 
-    function testFailFuzzApproveWithGarbage(
+    function test_RevertWhen_FuzzTransferFromWithGarbage(
+        address from,
         address to,
         uint256 amount,
         bytes memory garbage,
         bytes calldata brutalizeWith
     ) public brutalizeMemory(brutalizeWith) {
-        require(garbageIsGarbage(garbage));
+        vm.assume(garbageIsGarbage(garbage));
 
         returnsGarbage.setGarbage(garbage);
 
-        verifySafeApprove(address(returnsGarbage), to, amount);
+        vm.expectRevert();
+        this.verifySafeTransferFrom(address(returnsGarbage), from, to, amount);
     }
 
-    function testFailFuzzTransferETHToContractWithoutFallback(uint256 amount, bytes calldata brutalizeWith)
+    function test_RevertWhen_FuzzApproveWithReturnsFalse(
+        address to,
+        uint256 amount,
+        bytes calldata brutalizeWith
+    ) public brutalizeMemory(brutalizeWith) {
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsFalse), to, amount);
+    }
+
+    function test_RevertWhen_FuzzApproveWithReverting(
+        address to,
+        uint256 amount,
+        bytes calldata brutalizeWith
+    ) public brutalizeMemory(brutalizeWith) {
+        vm.expectRevert();
+        this.verifySafeApprove(address(reverting), to, amount);
+    }
+
+    function test_RevertWhen_FuzzApproveWithReturnsTooLittle(
+        address to,
+        uint256 amount,
+        bytes calldata brutalizeWith
+    ) public brutalizeMemory(brutalizeWith) {
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsTooLittle), to, amount);
+    }
+
+    function test_RevertWhen_FuzzApproveWithReturnsTwo(
+        address to,
+        uint256 amount,
+        bytes calldata brutalizeWith
+    ) public brutalizeMemory(brutalizeWith) {
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsTwo), to, amount);
+    }
+
+    function test_RevertWhen_FuzzApproveWithGarbage(
+        address to,
+        uint256 amount,
+        bytes memory garbage,
+        bytes calldata brutalizeWith
+    ) public brutalizeMemory(brutalizeWith) {
+        vm.assume(garbageIsGarbage(garbage));
+
+        returnsGarbage.setGarbage(garbage);
+
+        vm.expectRevert();
+        this.verifySafeApprove(address(returnsGarbage), to, amount);
+    }
+
+    function test_RevertWhen_FuzzTransferETHToContractWithoutFallback(uint256 amount, bytes calldata brutalizeWith)
         public
         brutalizeMemory(brutalizeWith)
     {
+        vm.expectRevert();
         SafeTransferLib.safeTransferETH(address(this), amount);
     }
 


### PR DESCRIPTION
Fixes `forge test` failing due to the following reasons:
- Duplicate ERC20 `APPROVE` macro
- Incorrect hardcoded bytecode sizes (define pre-`push0`)
- Duplicate imports (this is a compiler flaw tbh)
- Deprecated `testFail` pattern (big improvement to replace this pattern as we can define the exact timing and reason for reverts)
- `testReadBetweenOutOfBounds` occasionally failing due to exhausted fuzzing assumptions
- `testSafeBatchTransferFromToEOAFuzz` in self-transfer case