### PR TITLE
Fix ERC20 domain separator

### DIFF
--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -273,20 +273,29 @@
     // WARNING: 0x00 - 0x3f (64 bytes): scratch space for hashing methods
     // AS SUCH, WE STORE VARIABLES IN MEMORY STARTING AT 0x40
 
-    _GET_IMMUTABLE(NAME_OFFSET, 0xd0)   // [name]
+    // Load the adjacent `name_length` and `name` immutables in a single codecopy: name_length lives
+    // at code[codesize - NAME_LENGTH_OFFSET] and name directly after it (NAME_LENGTH_OFFSET -
+    // NAME_OFFSET == 0x20), so copying 0x40 bytes lands name_length at mem[0x40] and name at mem[0x60].
+    0x40 [NAME_LENGTH_OFFSET] codesize sub 0x40 codecopy    // []
 
-    [PERMIT_TYPEHASH] 0x40 mstore       // [name]
-    0x60 mstore                         // []
-    0x20 0x60 sha3 0x60 mstore          // []
+    // mem[0x60] = keccak256(bytes(name)): the name is stored left-aligned, so hash only its real
+    // length (mem[0x40]) rather than the full padded 32-byte word.
+    0x40 mload                          // [name_length]
+    0x60 sha3 0x60 mstore               // []
 
-    // 0x31 is hex for ascii for 1
-    0x31 0x80 mstore                    // []
-    0x02 0x80 sha3 0x80 mstore          // [hash of "1"]
+    // mem[0x40] = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+    // (overwrites the now-consumed name_length scratch)
+    [DOMAIN_TYPEHASH] 0x40 mstore       // []
 
-    chainid 0xa0 mstore                 // [chainid]
-    address 0xc0 mstore                 // [address(this)]
+    // mem[0x80] = keccak256(bytes("1")): store "1" (0x31) left-aligned and hash its 1 real byte
+    // (the previous code hashed keccak256(0x0000) instead).
+    0x3100000000000000000000000000000000000000000000000000000000000000 0x80 mstore
+    0x01 0x80 sha3 0x80 mstore          // []
 
-    0xA0 0x40 sha3                      // [hash]
+    chainid 0xa0 mstore                 // []
+    address 0xc0 mstore                 // []
+
+    0xA0 0x40 sha3                      // [domain separator]
 }
 
 /// @notice Permit

--- a/src/tokens/ERC20.huff
+++ b/src/tokens/ERC20.huff
@@ -48,6 +48,8 @@
 
 // PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 #define constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9
+// DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+#define constant DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f
 #define constant X_1901 = 0x1901000000000000000000000000000000000000000000000000000000000000
 
 // Utility Constants

--- a/test/tokens/ERC20.t.sol
+++ b/test/tokens/ERC20.t.sol
@@ -78,6 +78,33 @@ contract ERC20Test is Test {
         assertEq(mockTokenDecimals, DECIMALS);
     }
 
+    function testDomainSeparatorIsEIP712Compliant() public {
+        bytes32 expected = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(NAME)),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(token)
+            )
+        );
+        assertEq(token.DOMAIN_SEPARATOR(), expected);
+
+        // End-to-end: a permit signed against the canonical domain separator must be accepted.
+        uint256 ownerPk = 0xA11CE;
+        address owner = vm.addr(ownerPk);
+        address spender = address(0xCAFE);
+        uint256 value = 1e18;
+        uint256 deadline = block.timestamp;
+
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, uint256(0), deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", expected, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPk, digest);
+
+        token.permit(owner, spender, value, deadline, v, r, s);
+        assertEq(token.allowance(owner, spender), value);
+    }
+
     function testNonPayable() public {
         vm.deal(address(this), 10 ether);
 


### PR DESCRIPTION
Fixes:
- Uses `PERMIT_TYPEHASH` where `DOMAIN_TYPEHASH` should be used
- Incorrect name and version hashes

Uses https://github.com/huff-language/huffmate/pull/148 as base branch because ERC20.huff wasn't compiling

Contract was not deployed onchain