### PR TITLE
Fix onERC1155Received selector alignment

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -46,6 +46,7 @@ fs_permissions = [
     { access = "read", path = "./test/utils/mocks/ShufflingWrappers.huff" },
     { access = "read", path = "./test/utils/mocks/InsertionSortWrappers.huff" },
     { access = "read", path = "./test/utils/mocks/SSTORE2Wrappers.huff" },
+    { access = "read", path = "./test/utils/mocks/ERC1155ReceiverWrappers.huff" },
     { access = "read", path = "./test/utils/mocks/TSOwnableWrappers.huff" },
     { access = "read", path = "./test/utils/mocks/ECDSAWrappers.huff" },
     { access = "read", path = "./test/utils/mocks/ConstantsWrappers.huff" },

--- a/src/utils/ERC1155Receiver.huff
+++ b/src/utils/ERC1155Receiver.huff
@@ -7,6 +7,6 @@
 /// @notice Returns the function selector for `onERC1155Received`
 #define macro ON_ERC1155_RECEIVED() = takes (0) returns (0) {
     // 0xf23a6e61 is the 4byte function selector for `onERC1155Received`
-    0xf23a6e61 0x00 mstore    // []
-    0x20 0x00 return          // []
+    0xf23a6e61 0xe0 shl 0x00 mstore    // []
+    0x20 0x00 return                   // []
 }

--- a/test/utils/ERC1155Receiver.t.sol
+++ b/test/utils/ERC1155Receiver.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import "foundry-huff/HuffDeployer.sol";
+import "forge-std/Test.sol";
+
+interface IERC1155Receiver {
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external returns (bytes4);
+}
+
+contract ERC1155ReceiverTest is Test {
+    IERC1155Receiver receiver;
+
+    function setUp() public {
+        string memory wrapper_code = vm.readFile("test/utils/mocks/ERC1155ReceiverWrappers.huff");
+        receiver = IERC1155Receiver(HuffDeployer.deploy_with_code("utils/ERC1155Receiver", wrapper_code));
+    }
+
+    function testOnERC1155ReceivedReturnsSelector() public {
+        bytes4 ret = receiver.onERC1155Received(address(0xBEEF), address(0xCAFE), 1337, 1, "");
+        assertEq(ret, IERC1155Receiver.onERC1155Received.selector);
+    }
+}

--- a/test/utils/mocks/ERC1155ReceiverWrappers.huff
+++ b/test/utils/mocks/ERC1155ReceiverWrappers.huff
@@ -1,0 +1,9 @@
+#define function onERC1155Received(address,address,uint256,uint256,bytes) nonpayable returns (bytes4)
+
+#define macro MAIN() = takes (0) returns (0) {
+    0x00 calldataload 0xE0 shr
+    __FUNC_SIG(onERC1155Received) eq received jumpi
+    0x00 0x00 revert
+    received:
+        ON_ERC1155_RECEIVED()
+}


### PR DESCRIPTION
onERC1155Received selector is incorrectly right-aligned, resulting in all safeTransfers reverting unexpectedly